### PR TITLE
Adding subjects

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"@prisma/client": "6.1.0",
 		"@tailwindcss/forms": "^0.5.9",
 		"@tailwindcss/typography": "^0.5.15",
+		"@thisux/sveltednd": "^0.0.19",
 		"postgres": "^3.4.5",
 		"tsx": "^4.19.2"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.15(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))
+      '@thisux/sveltednd':
+        specifier: ^0.0.19
+        version: 0.0.19(svelte@5.16.0)
       postgres:
         specifier: ^3.4.5
         version: 3.4.5
@@ -903,6 +906,19 @@ packages:
     resolution: {integrity: sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20'
+
+  '@thisux/sveltednd@0.0.14':
+    resolution: {integrity: sha512-Vbq69SU3HUomPg6oCXtb89OG89hka0YIkdaErYibn3waK7tYE66IcQxD/Fzg8YNW3EVsXoA9kc7kW5EUBCSQGg==}
+
+  '@thisux/sveltednd@0.0.17':
+    resolution: {integrity: sha512-lRninjw439phhA8xAHqCpMAX0hnwFMdbXW4M0XJgAdnGxeum+QsLiIC4P3HnkNXAygsVKUqxRcbS84CxDZ9hPw==}
+    peerDependencies:
+      svelte: ^5.0.0
+
+  '@thisux/sveltednd@0.0.19':
+    resolution: {integrity: sha512-SqqkmO3EyrdE+hjmy0N7ogYiDVK7qIUoNtS5T+Tx+sMVUFnJYVqDnxUOu8w7EhwCmWxu/C/XIgUb5+ag/PxEKg==}
+    peerDependencies:
+      svelte: ^5.0.0
 
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
@@ -3121,6 +3137,18 @@ snapshots:
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
+
+  '@thisux/sveltednd@0.0.14': {}
+
+  '@thisux/sveltednd@0.0.17(svelte@5.16.0)':
+    dependencies:
+      '@thisux/sveltednd': 0.0.14
+      svelte: 5.16.0
+
+  '@thisux/sveltednd@0.0.19(svelte@5.16.0)':
+    dependencies:
+      '@thisux/sveltednd': 0.0.17(svelte@5.16.0)
+      svelte: 5.16.0
 
   '@tsconfig/node10@1.0.11':
     optional: true

--- a/prisma/init.ts
+++ b/prisma/init.ts
@@ -2,6 +2,22 @@
 // Run the following command to upload the data:
 // pnpm prisma db seed
 
+export const subjects = [
+	{ name: 'SubjectOne' },
+	{ name: 'SubjectTwo' },
+	{ name: 'SubjectThree' },
+	{ name: 'SubjectFour' }
+];
+
+export const domains = [
+	{ name: 'DomainOne' },
+	{ name: 'DomainTwo' },
+	{ name: 'DomainThree' },
+	{ name: 'DomainFour' }
+];
+
+export const graph = [{ name: 'GraphOne' }];
+
 export const courses = [
 	{
 		code: 'CS1000',

--- a/prisma/migrations/20250109143921_added_subjects/migration.sql
+++ b/prisma/migrations/20250109143921_added_subjects/migration.sql
@@ -1,0 +1,80 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name,graphId]` on the table `Domain` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateTable
+CREATE TABLE "Subject" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL DEFAULT '',
+    "order" INTEGER NOT NULL,
+    "x" INTEGER NOT NULL DEFAULT 0,
+    "y" INTEGER NOT NULL DEFAULT 0,
+    "graphId" INTEGER NOT NULL,
+    "domainId" INTEGER,
+
+    CONSTRAINT "Subject_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Lecture" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL DEFAULT '',
+    "order" INTEGER NOT NULL,
+    "graphId" INTEGER NOT NULL,
+
+    CONSTRAINT "Lecture_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_SubjectRelation" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_SubjectRelation_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateTable
+CREATE TABLE "_LectureToSubject" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_LectureToSubject_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Subject_name_domainId_key" ON "Subject"("name", "domainId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Lecture_name_graphId_key" ON "Lecture"("name", "graphId");
+
+-- CreateIndex
+CREATE INDEX "_SubjectRelation_B_index" ON "_SubjectRelation"("B");
+
+-- CreateIndex
+CREATE INDEX "_LectureToSubject_B_index" ON "_LectureToSubject"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Domain_name_graphId_key" ON "Domain"("name", "graphId");
+
+-- AddForeignKey
+ALTER TABLE "Subject" ADD CONSTRAINT "Subject_graphId_fkey" FOREIGN KEY ("graphId") REFERENCES "Graph"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Subject" ADD CONSTRAINT "Subject_domainId_fkey" FOREIGN KEY ("domainId") REFERENCES "Domain"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Lecture" ADD CONSTRAINT "Lecture_graphId_fkey" FOREIGN KEY ("graphId") REFERENCES "Graph"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_SubjectRelation" ADD CONSTRAINT "_SubjectRelation_A_fkey" FOREIGN KEY ("A") REFERENCES "Subject"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_SubjectRelation" ADD CONSTRAINT "_SubjectRelation_B_fkey" FOREIGN KEY ("B") REFERENCES "Subject"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_LectureToSubject" ADD CONSTRAINT "_LectureToSubject_A_fkey" FOREIGN KEY ("A") REFERENCES "Lecture"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_LectureToSubject" ADD CONSTRAINT "_LectureToSubject_B_fkey" FOREIGN KEY ("B") REFERENCES "Subject"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,10 +48,10 @@ model Graph {
   name     String
   courseId String
 
-  course  Course   @relation(fields: [courseId], references: [code])
-  domains Domain[]
-  // subjects		Subject[]
-  // lectures		Lecture[]
+  course   Course    @relation(fields: [courseId], references: [code])
+  domains  Domain[]
+  subjects Subject[]
+  lectures Lecture[]
   // links			Link[]
 
   createdAt DateTime @default(now())
@@ -74,8 +74,7 @@ enum DomainStyle {
 }
 
 model Domain {
-  id Int @id @default(autoincrement())
-
+  id    Int          @id @default(autoincrement())
   name  String
   style DomainStyle?
   order Int // Domains is a SORTABLE ARRAY this order makes sure this order is perserved on reload
@@ -85,8 +84,43 @@ model Domain {
   y Int @default(0)
 
   graphId          Int
-  graph            Graph    @relation(fields: [graphId], references: [id], onDelete: Cascade)
-  // subjects      Subject[]
-  incommingDomains Domain[] @relation("DomainRelation")
-  outgoingDomains  Domain[] @relation("DomainRelation")
+  graph            Graph     @relation(fields: [graphId], references: [id], onDelete: Cascade)
+  subjects         Subject[]
+  incommingDomains Domain[]  @relation("DomainRelation")
+  outgoingDomains  Domain[]  @relation("DomainRelation")
+
+  @@unique([name, graphId])
+}
+
+model Subject {
+  id    Int    @id @default(autoincrement())
+  name  String @default("")
+  order Int // Subjects is a SORTABLE ARRAY this order makes sure this order is perserved on reload
+
+  // Physical position in the graph
+  x Int @default(0)
+  y Int @default(0)
+
+  graphId  Int
+  domainId Int?
+  graph    Graph     @relation(fields: [graphId], references: [id], onDelete: Cascade)
+  domain   Domain?   @relation(fields: [domainId], references: [id])
+  lectures Lecture[]
+
+  incommingSubjects Subject[] @relation("SubjectRelation")
+  outgoingSubjects  Subject[] @relation("SubjectRelation")
+
+  @@unique([name, domainId])
+}
+
+model Lecture {
+  id      Int    @id @default(autoincrement())
+  name    String @default("")
+  order   Int
+  graphId Int
+
+  graph    Graph     @relation(fields: [graphId], references: [id], onDelete: Cascade)
+  subjects Subject[]
+
+  @@unique([name, graphId])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,16 +1,18 @@
-import { PrismaClient } from '@prisma/client';
-import { courses, programs } from './init';
+import { Course, Subject, PrismaClient } from '@prisma/client';
+import { courses, domains, programs, subjects } from './init';
 
 const prisma = new PrismaClient();
 
 async function main() {
 	console.log(`Start seeding ...`);
+	const cs: Course[] = [];
 	for (const course of courses) {
 		const c = await prisma.course.create({
 			data: {
 				...course
 			}
 		});
+		cs.push(c);
 		console.log(`Created course with id: ${c.code}`);
 	}
 
@@ -31,6 +33,71 @@ async function main() {
 		});
 		console.log(`Created program with id: ${p.id}`);
 	}
+
+	console.log('\n');
+
+	const graph = await prisma.graph.create({
+		data: { name: 'GraphOne', courseId: cs[0].code }
+	});
+
+	console.log(`Created graph with id: ${graph.id} \n`);
+
+	for (let i = 0; i < domains.length; i++) {
+		const domain = domains[i];
+		const d = await prisma.domain.create({
+			data: {
+				name: domain.name,
+				order: i,
+				graphId: graph.id
+			}
+		});
+		console.log(`Created domain with id: ${d.id}`);
+	}
+
+	const subjectsList: Subject[] = [];
+	for (let i = 0; i < subjects.length; i++) {
+		const subject = subjects[i];
+		const s = await prisma.subject.create({
+			data: {
+				name: subject.name,
+				order: i,
+				graphId: graph.id
+			}
+		});
+		subjectsList.push(s);
+		console.log(`Created subject with id: ${s.id}`);
+	}
+
+	console.log('\n');
+
+	await prisma.lecture.create({
+		data: {
+			name: 'LectureOne',
+			order: 0,
+			graphId: graph.id,
+			// Connect to subject 1,2,3
+			subjects: {
+				connect: [
+					{ id: subjectsList[0].id },
+					{ id: subjectsList[1].id },
+					{ id: subjectsList[2].id }
+				]
+			}
+		}
+	});
+
+	await prisma.lecture.create({
+		data: {
+			name: 'LectureTwo',
+			order: 1,
+			graphId: graph.id,
+			// Connect to subject 4,5
+			subjects: {
+				connect: [{ id: subjectsList[3].id }]
+			}
+		}
+	});
+
 	console.log(`Seeding finished.`);
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -72,7 +72,7 @@
 	html,
 	body {
 		scroll-behavior: smooth;
-		scroll-padding: 4rem;
+		scroll-padding: 8rem;
 		@apply bg-blue-50 text-foreground;
 	}
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from '@prisma/client';
 import { type ClassValue, clsx } from 'clsx';
+import { tick } from 'svelte';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
@@ -19,3 +20,10 @@ export type OrError<T extends object> =
 	| (Partial<T> & {
 			error: string;
 	  });
+
+export function closeAndFocusTrigger(triggerId: string, callback: () => void) {
+	callback();
+	tick().then(() => {
+		document.getElementById(triggerId)?.focus();
+	});
+}

--- a/src/lib/utils/settings.ts
+++ b/src/lib/utils/settings.ts
@@ -24,3 +24,6 @@ export const COLORS = {
 	SERIOUS_BROWN: '#8D6E63'
 };
 export const COLOR_KEYS = Object.keys(COLORS) as (keyof typeof COLORS)[];
+
+// SUBJECT
+export const MAX_SUBJECT_NAME_LENGTH = 50;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,6 +20,6 @@
 	});
 </script>
 
-<Toaster />
+<Toaster closeButton />
 
 {@render children()}

--- a/src/routes/NewCourseForm.svelte
+++ b/src/routes/NewCourseForm.svelte
@@ -3,7 +3,6 @@
 	import * as Command from '$lib/components/ui/command/index.js';
 	import * as Form from '$lib/components/ui/form/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
-
 	import * as Popover from '$lib/components/ui/popover';
 	import { cn } from '$lib/utils';
 	import { useId } from 'bits-ui';

--- a/src/routes/Program.svelte
+++ b/src/routes/Program.svelte
@@ -27,13 +27,6 @@
 
 	// Select out the courses that are not in the program yet
 	const programCourseSet = $derived(new Set(program.courses.map((c) => c.code)));
-
-	// courses are awaited 10s
-	const coursesArtifical = $derived.by(() => {
-		return new Promise<Course[]>((resolve) => {
-			setTimeout(async () => resolve(await courses), 5000);
-		});
-	});
 </script>
 
 <div
@@ -76,7 +69,7 @@
 		</Popover.Trigger>
 		<Popover.Content class="p-2" side="right" align="start">
 			<Command.Root>
-				{#await coursesArtifical}
+				{#await courses}
 					<CreateNewCourseButton {courseForm} {courseValue} {program} />
 					<p>
 						Loading courses (I have added an artifical wait of 5s to test what would happen if this

--- a/src/routes/courses/[code]/+page.server.ts
+++ b/src/routes/courses/[code]/+page.server.ts
@@ -26,6 +26,18 @@ export const load = (async ({ params }) => {
 		const dbCourse = await prisma.course.findFirst({
 			where: {
 				code: params.code
+			},
+			include: {
+				graphs: {
+					include: {
+						_count: {
+							select: {
+								domains: true,
+								subjects: true
+							}
+						}
+					}
+				}
 			}
 		});
 
@@ -34,18 +46,12 @@ export const load = (async ({ params }) => {
 			return result;
 		}
 
-		const graphs = await prisma.graph.findMany({
-			where: {
-				courseId: params.code
-			}
-		});
-
 		// Happy path
 		return {
 			error: undefined,
 			graphSchema: await superValidate(zod(graphSchema)),
 			course: dbCourse,
-			graphs
+			graphs: dbCourse.graphs
 		};
 	} catch (e: unknown) {
 		result.error = e instanceof Error ? e.message : `${e}`;

--- a/src/routes/courses/[code]/+page.svelte
+++ b/src/routes/courses/[code]/+page.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/button/button.svelte';
-	import { preventDefault } from 'svelte/legacy';
-	import type { PageData } from './$types';
-	import CreateNewGraphButton from './CreateNewGraphButton.svelte';
 	import ArrowRight from 'lucide-svelte/icons/arrow-right';
 	import { toast } from 'svelte-sonner';
+	import type { PageData } from './$types';
+	import CreateNewGraphButton from './CreateNewGraphButton.svelte';
 
 	let { data }: { data: PageData } = $props();
 </script>
@@ -51,21 +50,29 @@
 					<Button class="transition-colors group-hover:bg-blue-500">
 						View/Edit <ArrowRight />
 					</Button>
-					<Button
-						onclick={preventDefault(() =>
-							toast.success('WIP: Open duplication popup', {
-								description:
-									'Can be duplicated to any other course that the user has permissions to'
-							})
-						)}>Duplicate</Button
-					>
-					<Button
-						onclick={preventDefault(() =>
-							toast.success('WIP: Open settings modal', {
-								description: "Settings includes: 'delete', 'change name', 'duplicate'"
-							})
-						)}>Settings</Button
-					>
+					<div class="flex flex-col gap-1 lg:flex-row">
+						<Button
+							class="w-full"
+							onclick={(e) => {
+								e.preventDefault();
+								toast.success('WIP: Open duplication popup', {
+									description:
+										'Can be duplicated to any other course that the user has permissions to'
+								});
+							}}>Duplicate</Button
+						>
+						<Button
+							class="w-full"
+							onclick={(e) => {
+								e.preventDefault();
+								toast.success('WIP: Open settings modal', {
+									description: "Settings includes: 'delete', 'change name', 'duplicate'"
+								});
+							}}
+						>
+							Settings
+						</Button>
+					</div>
 				</div>
 			</a>
 		{/each}

--- a/src/routes/courses/[code]/+page.svelte
+++ b/src/routes/courses/[code]/+page.svelte
@@ -43,9 +43,8 @@
 			>
 				<div class="grow">
 					<h2 class="text-xl font-bold text-blue-950">{graph.name}</h2>
-					<p>Connection: 0</p>
-					<p>Domains: 0</p>
-					<p>Subjects: 0</p>
+					<p>Domains: {graph._count.domains}</p>
+					<p>Subjects: {graph._count.subjects}</p>
 				</div>
 
 				<div class="flex grow-0 flex-col gap-1">

--- a/src/routes/courses/[code]/graphs/[graphid]/+page.server.ts
+++ b/src/routes/courses/[code]/graphs/[graphid]/+page.server.ts
@@ -33,7 +33,14 @@ export const load = (async ({ params }) => {
 								incommingDomains: true,
 								outgoingDomains: true
 							}
-						}
+						},
+						subjects: {
+							include: {
+								incommingSubjects: true,
+								outgoingSubjects: true
+							}
+						},
+						lectures: true
 					}
 				}
 			}

--- a/src/routes/courses/[code]/graphs/[graphid]/+page.svelte
+++ b/src/routes/courses/[code]/graphs/[graphid]/+page.svelte
@@ -24,7 +24,7 @@
 		return tabs;
 	});
 
-	let tabValue = $state('Subjects');
+	let tabValue = $state('Domains');
 
 	$effect(() => {
 		// Make sure there are never two tabs of preview opened

--- a/src/routes/courses/[code]/graphs/[graphid]/+page.svelte
+++ b/src/routes/courses/[code]/graphs/[graphid]/+page.svelte
@@ -7,6 +7,9 @@
 	import Preview from './Preview.svelte';
 	import { toast } from 'svelte-sonner';
 	import { goto } from '$app/navigation';
+	import Subjects from './Subjects.svelte';
+	import Lectures from './Lectures.svelte';
+	import { cn } from '$lib/utils';
 
 	let { data }: { data: PageData } = $props();
 
@@ -48,7 +51,7 @@
 </nav>
 
 <div class="prose mx-auto flex max-w-[80rem] gap-2 p-4 text-blue-900">
-	<div class="grow rounded-xl bg-blue-100/50 p-4">
+	<div class={cn('w-1/2 rounded-xl bg-blue-100/50 p-4', { 'w-full': !medium.current })}>
 		<Tabs.Root bind:value={tabValue}>
 			<Tabs.List class="w-full">
 				{#each tabs as tab}
@@ -60,13 +63,19 @@
 					<Domains {...data} />
 				{/key}
 			</Tabs.Content>
-			<Tabs.Content value="Subjects">Make subjects</Tabs.Content>
-			<Tabs.Content value="Lectures">Wrap subjects in lectures.</Tabs.Content>
+			<Tabs.Content value="Subjects">
+				<Subjects {...data} />
+			</Tabs.Content>
+			<Tabs.Content value="Lectures">
+				<Lectures {...data} />
+			</Tabs.Content>
 			<Tabs.Content value="Preview"><Preview course={data.course} /></Tabs.Content>
 		</Tabs.Root>
 	</div>
 
-	{#if medium.current}
-		<Preview course={data.course} />
-	{/if}
+	<div class="w-1/2">
+		{#if medium.current}
+			<Preview course={data.course} />
+		{/if}
+	</div>
 </div>

--- a/src/routes/courses/[code]/graphs/[graphid]/+page.svelte
+++ b/src/routes/courses/[code]/graphs/[graphid]/+page.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import * as Tabs from '$lib/components/ui/tabs/index.js';
+	import { cn } from '$lib/utils';
+	import { toast } from 'svelte-sonner';
 	import { MediaQuery } from 'svelte/reactivity';
-	import { fade } from 'svelte/transition';
 	import type { PageData } from './$types';
 	import Domains from './Domains.svelte';
-	import Preview from './Preview.svelte';
-	import { toast } from 'svelte-sonner';
-	import { goto } from '$app/navigation';
-	import Subjects from './Subjects.svelte';
 	import Lectures from './Lectures.svelte';
-	import { cn } from '$lib/utils';
+	import Preview from './Preview.svelte';
+	import Subjects from './Subjects.svelte';
+	import { onMount } from 'svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -23,59 +24,65 @@
 		return tabs;
 	});
 
-	let tabValue = $state('Domains');
+	let tabValue = $state('Subjects');
 
 	$effect(() => {
 		// Make sure there are never two tabs of preview opened
 		if (medium.current && tabValue === 'Preview') tabValue = 'Domains';
+	});
 
+	onMount(() => {
 		if (data.cycles) {
 			const from = data.cycles.from;
 			const to = data.cycles.to;
-			toast.warning('This graph contains cycles', {
+			toast.warning('Graph contains a domain cycle', {
 				duration: Number.POSITIVE_INFINITY,
 				description: `from ${from.name} to ${to.name}`,
 				action: {
 					label: 'Go to cycle',
-					onClick: () => goto(`#domain-rel-${from.id}-${to.id}`)
+					onClick: () => {
+						tabValue = 'Domains';
+						goto(`#domain-rel-${from.id}-${to.id}`);
+					}
 				}
 			});
 		}
 	});
 </script>
 
-<nav class="border-b-2 border-blue-300 bg-blue-200 p-4">
+<nav class="fixed z-10 w-full border-b-2 border-blue-300 bg-blue-200/80 p-4 backdrop-blur-sm">
 	<a href="/">Home</a>
 	<a href="/courses">Courses</a>
 	<a href="/courses/{data.course.code}">{data.course.name}</a>
 </nav>
 
-<div class="prose mx-auto flex max-w-[80rem] gap-2 p-4 text-blue-900">
-	<div class={cn('w-1/2 rounded-xl bg-blue-100/50 p-4', { 'w-full': !medium.current })}>
-		<Tabs.Root bind:value={tabValue}>
-			<Tabs.List class="w-full">
-				{#each tabs as tab}
-					<Tabs.Trigger class="w-full" value={tab}>{tab}</Tabs.Trigger>
-				{/each}
-			</Tabs.List>
+<div class="prose mx-auto flex max-w-[80rem] gap-2 p-4 pt-20 text-blue-900">
+	<Tabs.Root class={cn('w-full', { 'mx-auto w-1/2': medium.current })} bind:value={tabValue}>
+		<Tabs.List class="sticky top-16 z-10 mb-2 w-full bg-blue-100 py-6 shadow-md">
+			{#each tabs as tab}
+				<Tabs.Trigger class="w-full" value={tab}>{tab}</Tabs.Trigger>
+			{/each}
+		</Tabs.List>
+
+		<div class="w-full rounded-xl bg-blue-100/50 p-4">
 			<Tabs.Content value="Domains">
 				{#key data}
 					<Domains {...data} />
 				{/key}
 			</Tabs.Content>
 			<Tabs.Content value="Subjects">
-				<Subjects {...data} />
+				<Subjects bind:tabValue {...data} />
 			</Tabs.Content>
 			<Tabs.Content value="Lectures">
 				<Lectures {...data} />
 			</Tabs.Content>
 			<Tabs.Content value="Preview"><Preview course={data.course} /></Tabs.Content>
-		</Tabs.Root>
-	</div>
+		</div>
+	</Tabs.Root>
 
-	<div class="w-1/2">
-		{#if medium.current}
+	{#if medium.current}
+		<div class="w-1/2">
 			<Preview course={data.course} />
-		{/if}
-	</div>
+		</div>
+	{/if}
 </div>

--- a/src/routes/courses/[code]/graphs/[graphid]/CreateNewSubject.svelte
+++ b/src/routes/courses/[code]/graphs/[graphid]/CreateNewSubject.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	import DialogButton from '$lib/components/DialogButton.svelte';
+	import * as Form from '$lib/components/ui/form/index.js';
+	import { Input } from '$lib/components/ui/input';
+	import * as Popover from '$lib/components/ui/popover';
+	import type { Domain, Graph } from '@prisma/client';
+	import { useId } from 'bits-ui';
+	import { toast } from 'svelte-sonner';
+	import { type Infer, superForm, type SuperValidated } from 'sveltekit-superforms';
+	import { zodClient } from 'sveltekit-superforms/adapters';
+	import { subjectSchema } from './zodSchema';
+	import { closeAndFocusTrigger, cn } from '$lib/utils';
+	import { buttonVariants } from '$lib/components/ui/button';
+	import ChevronsUpDown from 'lucide-svelte/icons/chevrons-up-down';
+	import * as Command from '$lib/components/ui/command/index.js';
+	import Check from 'lucide-svelte/icons/check';
+
+	type Props = {
+		graph: Graph & { domains: Domain[] };
+		form: SuperValidated<Infer<typeof subjectSchema>>;
+	};
+
+	const { form: graphForm, graph }: Props = $props();
+
+	const triggerId = useId();
+
+	let dialogOpen = $state(false);
+	let domainIdOpen = $state(false);
+
+	const form = superForm(graphForm, {
+		validators: zodClient(subjectSchema),
+		onResult: ({ result }) => {
+			if (result.type == 'success') {
+				toast.success('Subject created successfully!');
+				dialogOpen = false;
+			}
+		}
+	});
+
+	const { form: formData, enhance } = form;
+</script>
+
+<DialogButton
+	bind:open={dialogOpen}
+	icon="plus"
+	button="New Subject"
+	title="Create Subject"
+	description="A subject can be related to other subject."
+>
+	<!-- For sumbitting a NEW PROGRAM
+ 	It triggers an action that can be seen in +page.server.ts -->
+	<form action="?/add-subject-to-graph" method="POST" use:enhance>
+		<input type="hidden" name="graphId" value={graph.id} />
+
+		<Form.Field {form} name="name">
+			<Form.Control>
+				{#snippet children({ props })}
+					<Form.Label for="name">Subject name</Form.Label>
+					<Input {...props} bind:value={$formData.name} />
+				{/snippet}
+			</Form.Control>
+			<Form.Description>A common name for a subject</Form.Description>
+			<Form.FieldErrors />
+		</Form.Field>
+
+		<Form.Field {form} name="domainId">
+			<Popover.Root bind:open={domainIdOpen}>
+				<Form.Control id={triggerId}>
+					{#snippet children({ props })}
+						<div class="mt-2 flex w-full items-center justify-between">
+							<Form.Label>Link to domain (optional)</Form.Label>
+							<Popover.Trigger
+								class={cn(buttonVariants({ variant: 'outline' }), 'min-w-[50%] justify-between')}
+								role="combobox"
+								{...props}
+							>
+								{graph.domains.find((f) => f.id === $formData.domainId)?.name ?? 'Select domain'}
+								<ChevronsUpDown class="opacity-50" />
+							</Popover.Trigger>
+							<input hidden value={$formData.domainId} name={props.name} />
+						</div>
+					{/snippet}
+				</Form.Control>
+				<Popover.Content>
+					<Command.Root>
+						<Command.Input autofocus placeholder="Search domain..." class="h-9" />
+						<Command.Empty>No domain found.</Command.Empty>
+						<Command.Group>
+							{#each graph.domains as domain}
+								<Command.Item
+									value={domain.id.toString()}
+									onSelect={() => {
+										$formData.domainId = domain.id;
+										closeAndFocusTrigger(triggerId, () => (domainIdOpen = false));
+									}}
+								>
+									{domain.name}
+									<Check
+										class={cn('ml-auto', domain.id !== $formData.domainId && 'text-transparent')}
+									/>
+								</Command.Item>
+							{/each}
+						</Command.Group>
+					</Command.Root>
+				</Popover.Content>
+			</Popover.Root>
+		</Form.Field>
+
+		<Form.Button class="float-right mt-4">Submit</Form.Button>
+	</form>
+</DialogButton>

--- a/src/routes/courses/[code]/graphs/[graphid]/Domains.svelte
+++ b/src/routes/courses/[code]/graphs/[graphid]/Domains.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import { Button } from '$lib/components/ui/button';
 	import * as Table from '$lib/components/ui/table/index.js';
 	import * as settings from '$lib/utils/settings';
+	import type { Domain } from '@prisma/client';
 	import Ellipsis from 'lucide-svelte/icons/ellipsis';
 	import MoveVertical from 'lucide-svelte/icons/move-vertical';
 	import { toast } from 'svelte-sonner';
 	import type { Infer, SuperValidated } from 'sveltekit-superforms';
 	import type { PageData } from './$types';
 	import CreateNewDomain from './CreateNewDomain.svelte';
-	import type { domainRelSchema, domainSchema } from './zodSchema';
-	import SortableList from './SortableList.svelte';
 	import CreateNewRelationship from './CreateNewRelationship.svelte';
-	import { page } from '$app/state';
-	import type { Domain } from '@prisma/client';
+	import SortableList from './SortableList.svelte';
+	import type { domainRelSchema, domainSchema } from './zodSchema';
 
 	type Props = {
 		course: PageData['course'];
@@ -53,46 +53,41 @@
 		</Table.Row>
 	</Table.Header>
 	<Table.Body>
-		<SortableList list={graph.domains} id="id">
-			{#snippet sortItems(domain, index, onDragOver, onDragStart, onDragEnd)}
-				<Table.Row
-					id="{domain.id}-{domain.name}"
-					class={[
-						'transition-colors delay-300',
-						page.url.hash == `#${domain.id}-${domain.name}` ? 'bg-blue-200' : 'bg-blue-200/0'
-					]}
-					data-index={index}
-					ondragover={onDragOver}
-					ondragstart={onDragStart}
-					ondragend={onDragEnd}
-					draggable="true"
-				>
-					<Table.Cell>
-						<Button variant="secondary" onclick={() => toast.warning('Not implemented')}>
-							<MoveVertical />
-						</Button>
-					</Table.Cell>
-					<Table.Cell class="max-w-40 overflow-hidden text-ellipsis text-nowrap">
-						{domain.name}
-					</Table.Cell>
-					<Table.Cell>
-						{#if domain.style}
-							<div
-								class="h-5 w-5 rounded-full border-2 border-slate-600"
-								style="background-color: {settings.COLORS[domain.style]}f0"
-							></div>
-						{:else}
-							None
-						{/if}
-					</Table.Cell>
-					<Table.Cell>{domain.incommingDomains.length}</Table.Cell>
-					<Table.Cell>{domain.outgoingDomains.length}</Table.Cell>
-					<Table.Cell>
-						<Button variant="outline" onclick={() => toast.warning('Not implemented')}>
-							<Ellipsis />
-						</Button>
-					</Table.Cell>
-				</Table.Row>
+		<SortableList
+			list={graph.domains}
+			onrearrange={(list) => console.log($state.snapshot(list))}
+			useId={(domain) => `${domain.id}-${domain.name}`}
+		>
+			{#snippet children(domain, index)}
+				<Table.Cell class="px-1">
+					<Button variant="secondary" onclick={() => toast.warning('Not implemented')}>
+						<MoveVertical />
+					</Button>
+				</Table.Cell>
+				<Table.Cell class="max-w-40 overflow-hidden text-ellipsis text-nowrap">
+					{domain.name}
+				</Table.Cell>
+				<Table.Cell>
+					{#if domain.style}
+						<div
+							class="h-5 w-5 rounded-full border-2 border-slate-600"
+							style="background-color: {settings.COLORS[domain.style]}f0"
+						></div>
+					{:else}
+						None
+					{/if}
+				</Table.Cell>
+				<Table.Cell>{domain.incommingDomains.length}</Table.Cell>
+				<Table.Cell>{domain.outgoingDomains.length}</Table.Cell>
+				<Table.Cell>
+					<Button
+						class="interactive"
+						variant="outline"
+						onclick={() => toast.warning('Not implemented')}
+					>
+						<Ellipsis />
+					</Button>
+				</Table.Cell>
 			{/snippet}
 		</SortableList>
 	</Table.Body>
@@ -149,3 +144,9 @@
 </Table.Root>
 
 <div class="h-dvh"></div>
+
+<style>
+	:global(.dragging) {
+		@apply opacity-50 shadow-lg ring-2 ring-blue-400;
+	}
+</style>

--- a/src/routes/courses/[code]/graphs/[graphid]/Domains.svelte
+++ b/src/routes/courses/[code]/graphs/[graphid]/Domains.svelte
@@ -36,7 +36,7 @@
 	});
 </script>
 
-<div class="mt-12 flex items-end justify-between">
+<div class="flex items-end justify-between">
 	<h2 class="m-0">Domains</h2>
 	<CreateNewDomain {graph} form={newDomainForm} />
 </div>
@@ -45,10 +45,10 @@
 	<Table.Header>
 		<Table.Row>
 			<Table.Head class="w-12"></Table.Head>
-			<Table.Head>Name</Table.Head>
+			<Table.Head class="max-w-12">Name</Table.Head>
 			<Table.Head>Color</Table.Head>
-			<Table.Head>Incomming</Table.Head>
-			<Table.Head>Outgoing</Table.Head>
+			<Table.Head>#In</Table.Head>
+			<Table.Head>#Out</Table.Head>
 			<Table.Head>Settings</Table.Head>
 		</Table.Row>
 	</Table.Header>
@@ -72,7 +72,9 @@
 							<MoveVertical />
 						</Button>
 					</Table.Cell>
-					<Table.Cell>{domain.name}</Table.Cell>
+					<Table.Cell class="max-w-40 overflow-hidden text-ellipsis text-nowrap">
+						{domain.name}
+					</Table.Cell>
 					<Table.Cell>
 						{#if domain.style}
 							<div

--- a/src/routes/courses/[code]/graphs/[graphid]/Lectures.svelte
+++ b/src/routes/courses/[code]/graphs/[graphid]/Lectures.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	type Props = {
+		course: PageData['course'];
+	};
+
+	const { course }: Props = $props();
+</script>
+
+<pre>
+  {JSON.stringify(course.graphs[0].lectures, null, 2)}
+</pre>

--- a/src/routes/courses/[code]/graphs/[graphid]/Preview.svelte
+++ b/src/routes/courses/[code]/graphs/[graphid]/Preview.svelte
@@ -8,6 +8,6 @@
 	let { course } = $props();
 </script>
 
-<div class="sticky top-12 h-[75dvh] w-full rounded-xl bg-blue-200/50 p-4">
+<div class="sticky top-16 h-[75dvh] w-full rounded-xl bg-blue-200/50 p-4">
 	<h2>Preview</h2>
 </div>

--- a/src/routes/courses/[code]/graphs/[graphid]/Preview.svelte
+++ b/src/routes/courses/[code]/graphs/[graphid]/Preview.svelte
@@ -9,5 +9,5 @@
 </script>
 
 <div class="sticky top-16 h-[75dvh] w-full rounded-xl bg-blue-200/50 p-4">
-	<h2>Preview</h2>
+	<h2 class="m-0">Preview</h2>
 </div>

--- a/src/routes/courses/[code]/graphs/[graphid]/Subjects.svelte
+++ b/src/routes/courses/[code]/graphs/[graphid]/Subjects.svelte
@@ -1,13 +1,92 @@
 <script lang="ts">
+	import { page } from '$app/state';
+	import { Button } from '$lib/components/ui/button';
+	import * as Table from '$lib/components/ui/table/index.js';
+	import Ellipsis from 'lucide-svelte/icons/ellipsis';
+	import Link from 'lucide-svelte/icons/link';
+	import MoveVertical from 'lucide-svelte/icons/move-vertical';
+	import { toast } from 'svelte-sonner';
 	import type { PageData } from './$types';
+	import CreateNewSubject from './CreateNewSubject.svelte';
+	import SortableList from './SortableList.svelte';
+	import type { subjectSchema } from './zodSchema';
+	import { type Infer, type SuperValidated } from 'sveltekit-superforms';
+	import { goto } from '$app/navigation';
 
 	type Props = {
 		course: PageData['course'];
+		tabValue: string;
+		newSubjectForm: SuperValidated<Infer<typeof subjectSchema>>;
 	};
 
-	const { course }: Props = $props();
+	let { course, tabValue = $bindable(), newSubjectForm }: Props = $props();
+
+	const graph = $derived(course.graphs[0]);
 </script>
 
-<pre>
-  {JSON.stringify(course.graphs[0].subjects, null, 2)}
-</pre>
+<div class="mt-12 flex items-end justify-between">
+	<h2 class="m-0">Subjects</h2>
+	<CreateNewSubject {graph} form={newSubjectForm} />
+</div>
+
+<Table.Root class="mt-2">
+	<Table.Header>
+		<Table.Row>
+			<Table.Head class="w-12"></Table.Head>
+			<Table.Head>Name</Table.Head>
+			<Table.Head class="flex items-center gap-1"><Link class="size-4" />Domain</Table.Head>
+			<Table.Head># In</Table.Head>
+			<Table.Head># Out</Table.Head>
+			<Table.Head>Edit</Table.Head>
+		</Table.Row>
+	</Table.Header>
+	<Table.Body>
+		<SortableList list={graph.subjects} id="id">
+			{#snippet sortItems(subject, index, onDragOver, onDragStart, onDragEnd)}
+				<Table.Row
+					id="{subject.id}-{subject.name}"
+					class={[
+						'transition-colors delay-300',
+						page.url.hash == `#${subject.id}-${subject.name}` ? 'bg-blue-200' : 'bg-blue-200/0'
+					]}
+					data-index={index}
+					ondragover={onDragOver}
+					ondragstart={onDragStart}
+					ondragend={onDragEnd}
+					draggable="true"
+				>
+					<Table.Cell>
+						<Button variant="secondary" onclick={() => toast.warning('Not implemented')}>
+							<MoveVertical />
+						</Button>
+					</Table.Cell>
+					<Table.Cell>{subject.name}</Table.Cell>
+					<Table.Cell>
+						{#if subject.domain}
+							<Button
+								variant="outline"
+								href="#{subject.domain!.id}-{subject.domain!.name}"
+								onclick={() => {
+									tabValue = 'Domains';
+								}}
+							>
+								{subject.domain.name}
+							</Button>
+						{:else}
+							<Button variant="outline" onclick={() => toast.warning('Not implemented')}>
+								{'None'}
+							</Button>
+						{/if}
+					</Table.Cell>
+					<Table.Cell>{subject.incommingSubjects.length}</Table.Cell>
+					<Table.Cell>{subject.incommingSubjects.length}</Table.Cell>
+					<Table.Cell>
+						<Button variant="outline" onclick={() => toast.warning('Not implemented')}>
+							<Ellipsis />
+						</Button>
+					</Table.Cell>
+				</Table.Row>
+			{/snippet}
+		</SortableList>
+	</Table.Body>
+</Table.Root>

--- a/src/routes/courses/[code]/graphs/[graphid]/Subjects.svelte
+++ b/src/routes/courses/[code]/graphs/[graphid]/Subjects.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	type Props = {
+		course: PageData['course'];
+	};
+
+	const { course }: Props = $props();
+</script>
+
+<pre>
+  {JSON.stringify(course.graphs[0].subjects, null, 2)}
+</pre>

--- a/src/routes/courses/[code]/graphs/[graphid]/zodSchema.ts
+++ b/src/routes/courses/[code]/graphs/[graphid]/zodSchema.ts
@@ -20,3 +20,10 @@ export const domainRelSchema = z
 		message: 'domainInId and domainOutId must not be the same',
 		path: ['domainInId', 'domainOutId']
 	});
+
+// Subjects
+export const subjectSchema = z.object({
+	graphId: z.number(),
+	name: z.string().min(1).max(settings.MAX_SUBJECT_NAME_LENGTH),
+	domainId: z.number()
+});


### PR DESCRIPTION

### Database Schema and Seeding

* Added new `Subject` and `Lecture` models to the Prisma schema, along with their relations to `Graph` and `Domain` models. [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL53-R54) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL89-R125)
* Updated `prisma/init.ts` to include initial data for subjects, domains, and graph.
* Created a new migration script to add `Subject` and `Lecture` tables, along with their indexes and foreign keys.
* Modified the seeding script (`prisma/seed.ts`) to seed the new `Subject` and `Lecture` data. [[1]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bL1-R15) [[2]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bR36-R100)

These changes collectively enhance the functionality of the application by introducing new models and their relationships, updating the seeding process, and improving the frontend components for better user interaction.