### PR TITLE
Feat/dark mode sidebar

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,8 +910,15 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
+  '@thisux/sveltednd@0.0.12':
+    resolution: {integrity: sha512-9edVcakYkoCzU6pNIwmJ6Cf+9anECod26Ue/rL3Ssf5LyuLaBLXtBx4H4U8YwQCkwtMeSGFf0OsiMpPpFjvCcg==}
+    peerDependencies:
+      svelte: ^5.0.0
+
   '@thisux/sveltednd@0.0.14':
     resolution: {integrity: sha512-Vbq69SU3HUomPg6oCXtb89OG89hka0YIkdaErYibn3waK7tYE66IcQxD/Fzg8YNW3EVsXoA9kc7kW5EUBCSQGg==}
+    peerDependencies:
+      svelte: ^5.0.0
 
   '@thisux/sveltednd@0.0.17':
     resolution: {integrity: sha512-lRninjw439phhA8xAHqCpMAX0hnwFMdbXW4M0XJgAdnGxeum+QsLiIC4P3HnkNXAygsVKUqxRcbS84CxDZ9hPw==}
@@ -3492,11 +3499,18 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
-  '@thisux/sveltednd@0.0.14': {}
+  '@thisux/sveltednd@0.0.12(svelte@5.28.2)':
+    dependencies:
+      svelte: 5.28.2
+
+  '@thisux/sveltednd@0.0.14(svelte@5.28.2)':
+    dependencies:
+      '@thisux/sveltednd': 0.0.12(svelte@5.28.2)
+      svelte: 5.28.2
 
   '@thisux/sveltednd@0.0.17(svelte@5.28.2)':
     dependencies:
-      '@thisux/sveltednd': 0.0.14
+      '@thisux/sveltednd': 0.0.14(svelte@5.28.2)
       svelte: 5.28.2
 
   '@thisux/sveltednd@0.0.19(svelte@5.28.2)':

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import NavigationBar from '$lib/components/NavigationBar.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Toaster } from '$lib/components/ui/sonner/index.js';
+	import { ModeWatcher } from "mode-watcher";
 
 	import type { User } from '@prisma/client';
 	import '../app.css';
@@ -21,6 +22,7 @@
 	);
 </script>
 
+<ModeWatcher />
 <Toaster closeButton />
 
 <NavigationBar />

--- a/src/routes/AppSidebar.svelte
+++ b/src/routes/AppSidebar.svelte
@@ -4,6 +4,10 @@
 	import type { User } from '@prisma/client';
 	import FooterSidebar from './FooterSidebar.svelte';
 	import { Home, LibraryBig, Notebook, User as UserIcon } from '@lucide/svelte';
+	import { SunIcon } from '@lucide/svelte/icons/sun';
+	import { MoonIcon } from '@lucide/svelte/icons/moon';
+	import { toggleMode } from 'mode-watcher';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { cn } from '$lib/utils';
 	import { page } from '$app/state';
@@ -80,6 +84,15 @@
 	</Sidebar.Content>
 
 	<Sidebar.Footer>
+		<Button onclick={toggleMode} variant="outline" size="icon" class="mx-auto mb-2">
+			<SunIcon
+				class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
+			/>
+			<MoonIcon
+				class="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
+			/>
+			<span class="sr-only">Toggle theme</span>
+		</Button>
 		<FooterSidebar {user} />
 	</Sidebar.Footer>
 	<Sidebar.Rail />


### PR DESCRIPTION
PR created by JULES (jules.google)

feat: Add dark mode toggle to sidebar

Integrates a dark mode toggle functionality into the application sidebar.

Key changes:
- Installed `mode-watcher` to handle theme state and toggling.
- Updated `+layout.svelte` to include the `ModeWatcher` component for global theme management.
- Added a theme toggle button (Sun/Moon icons) to `AppSidebar.svelte` in the footer section.
- Verified that `tailwind.config.ts` is correctly configured with `darkMode: 'class'`.

This allows you to switch between light and dark themes seamlessly.