### PR TITLE
fix: permission-scope unlink table, add search to link dialog

### DIFF
--- a/src/lib/components/addCourse/LinkCourseDataTable.svelte
+++ b/src/lib/components/addCourse/LinkCourseDataTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { createSvelteTable, FlexRender } from '$lib/components/ui/data-table/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import * as Table from '$lib/components/ui/table/index.js';
 	import type { linkingCoursesSchema } from '$lib/zod/programSchema';
 	import type { Course, Program, User } from '@prisma/client';
@@ -38,10 +39,26 @@
 
 	let pagination = $state<PaginationState>({ pageIndex: 0, pageSize: 4 });
 	let rowSelection = $state<RowSelectionState>({});
+	let search = $state('');
+
+	const filteredData = $derived(
+		search.trim() === ''
+			? data
+			: data.filter((c) => {
+					const q = search.trim().toLowerCase();
+					return c.name.toLowerCase().includes(q) || c.code.toLowerCase().includes(q);
+				})
+	);
+
+	$effect(() => {
+		void search;
+		pagination = { ...pagination, pageIndex: 0 };
+		rowSelection = {};
+	});
 
 	const table = createSvelteTable({
 		get data() {
-			return data;
+			return filteredData;
 		},
 		get columns() {
 			return columns;
@@ -73,6 +90,8 @@
 		getPaginationRowModel: getPaginationRowModel()
 	});
 </script>
+
+<Input placeholder="Search by name or code..." bind:value={search} class="mb-2" />
 
 <div class="rounded-md border">
 	<Table.Root class="m-0">
@@ -160,7 +179,7 @@
 				</Button>
 				<LinkCourses
 					onSuccess={() => (dialogOpen = false)}
-					courses={data}
+					courses={filteredData}
 					{program}
 					bind:rowSelection
 					{linkCoursesForm}

--- a/src/lib/components/addCourse/LinkCourseDataTable.svelte
+++ b/src/lib/components/addCourse/LinkCourseDataTable.svelte
@@ -52,7 +52,7 @@
 
 	$effect(() => {
 		void search;
-		pagination = { ...pagination, pageIndex: 0 };
+		pagination = { pageIndex: 0, pageSize: 4 };
 		rowSelection = {};
 	});
 

--- a/src/lib/server/actions/Courses.ts
+++ b/src/lib/server/actions/Courses.ts
@@ -177,6 +177,28 @@ export class CourseActions {
 	}
 
 	/**
+	 * Compute which of the given courses the user has course-level permission on, for
+	 * gating the unlink table's per-row eligibility.
+	 *
+	 * PERMISSIONS:
+	 * - Same tier `linkCourses` requires per course: CourseAdminEditor or ProgramAdminEditor
+	 *
+	 * @param user - The user performing the action
+	 * @param courseIds - The course ids to check
+	 * @returns `Set` of course ids the user is permitted to unlink
+	 */
+	static async getUnlinkEligibility(user: User, courseIds: number[]) {
+		const permittedCourses = await prisma.course.findMany({
+			where: {
+				id: { in: courseIds },
+				...whereHasCoursePermission(user, 'CourseAdminEditorORProgramAdminEditor')
+			},
+			select: { id: true }
+		});
+		return new Set(permittedCourses.map((c) => c.id));
+	}
+
+	/**
 	 * Rename a course.
 	 *
 	 * PERMISSIONS:

--- a/src/routes/graph-editor/programs/[programId=int]/settings/+page.server.ts
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/+page.server.ts
@@ -44,14 +44,10 @@ export const load = (async ({ params, locals }) => {
 
 		if (!dbProgram) throw Error('You do not have permissions to access this program setting page');
 
-		const permittedCourseIds = await prisma.course.findMany({
-			where: {
-				id: { in: dbProgram.courses.map((c) => c.id) },
-				...whereHasCoursePermission(user, 'CourseAdminEditorORProgramAdminEditor')
-			},
-			select: { id: true }
-		});
-		const permittedIds = new Set(permittedCourseIds.map((c) => c.id));
+		const permittedIds = await CourseActions.getUnlinkEligibility(
+			user,
+			dbProgram.courses.map((c) => c.id)
+		);
 
 		const programCourses = dbProgram.courses.map((c) => ({
 			...c,

--- a/src/routes/graph-editor/programs/[programId=int]/settings/+page.server.ts
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/+page.server.ts
@@ -44,6 +44,23 @@ export const load = (async ({ params, locals }) => {
 
 		if (!dbProgram) throw Error('You do not have permissions to access this program setting page');
 
+		const permittedCourseIds = await prisma.course.findMany({
+			where: {
+				id: { in: dbProgram.courses.map((c) => c.id) },
+				...whereHasCoursePermission(user, 'CourseAdminEditorORProgramAdminEditor')
+			},
+			select: { id: true }
+		});
+		const permittedIds = new Set(permittedCourseIds.map((c) => c.id));
+
+		const programCourses = dbProgram.courses.map((c) => ({
+			...c,
+			linkable: permittedIds.has(c.id),
+			reason: permittedIds.has(c.id)
+				? undefined
+				: 'You do not have permission to unlink this course'
+		}));
+
 		return {
 			breadcrumbs: [
 				{ name: 'Home', url: '/graph-editor' },
@@ -52,6 +69,7 @@ export const load = (async ({ params, locals }) => {
 				{ name: 'Settings', url: `/graph-editor/programs/${programId}/settings` }
 			],
 			program: dbProgram,
+			programCourses,
 			user,
 			allUsers,
 			allCourses,

--- a/src/routes/graph-editor/programs/[programId=int]/settings/+page.svelte
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/+page.svelte
@@ -75,7 +75,7 @@
 	</p>
 
 	<CoursesTable
-		data={data.program?.courses}
+		data={data.programCourses}
 		program={data.program}
 		{columns}
 		courses={data.allCourses}

--- a/src/routes/graph-editor/programs/[programId=int]/settings/courses/CoursesTable.svelte
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/courses/CoursesTable.svelte
@@ -13,6 +13,7 @@
 	// Types
 	import type { PageData } from '../$types';
 	import type { Course, Program, User } from '@prisma/client';
+	import type { UnlinkCandidate } from './course-columns';
 	import type {
 		ColumnDef,
 		PaginationState,
@@ -21,9 +22,9 @@
 	} from '@tanstack/table-core';
 
 	type DataTableProps = {
-		columns: ColumnDef<Course, Course>[];
+		columns: ColumnDef<UnlinkCandidate, UnlinkCandidate>[];
 		program: Program & { courses: Course[]; admins: User[]; editors: User[] };
-		data: Course[];
+		data: UnlinkCandidate[];
 		courses: Promise<Course[]>;
 	};
 
@@ -70,6 +71,7 @@
 				rowSelection = updater;
 			}
 		},
+		enableRowSelection: (row) => row.original.linkable,
 		getCoreRowModel: getCoreRowModel(),
 		getPaginationRowModel: getPaginationRowModel()
 	});
@@ -97,7 +99,9 @@
 			{#each table.getRowModel().rows as row (row.id)}
 				<Table.Row
 					data-state={row.getIsSelected() && 'selected'}
+					class={!row.original.linkable ? 'opacity-50' : ''}
 					onclick={() => {
+						if (!row.original.linkable) return;
 						const isSelected = rowSelection[row.id];
 						rowSelection = {
 							...rowSelection,

--- a/src/routes/graph-editor/programs/[programId=int]/settings/courses/UnlinkCourses.svelte
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/courses/UnlinkCourses.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { buttonVariants } from '$lib/components/ui/button/index.js';
+	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
 	import * as Form from '$lib/components/ui/form/index.js';
 	import { linkingCoursesSchema } from '$lib/zod/programSchema';
 	import type { Course, Program } from '@prisma/client';
@@ -17,6 +19,8 @@
 
 	let { program, rowSelection = $bindable() }: DataTableProps = $props();
 
+	let dialogOpen = $state(false);
+
 	const selectedCourses = $derived(
 		Object.entries(rowSelection)
 			.filter(([_, selected]) => selected) // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -32,6 +36,7 @@
 			if (result.type == 'success') {
 				toast.success('Succesfully unlinked courses!');
 
+				dialogOpen = false;
 				rowSelection = {};
 			}
 		}
@@ -46,28 +51,51 @@
 </script>
 
 <div in:fly={{ y: 10 }}>
-	<form action="?/unlink-courses" method="POST" use:enhance>
-		<input type="text" name="programId" value={program.id} hidden />
-
-		<Form.Fieldset {form} name="courseIds" class="h-0">
-			{#each $formData.courseIds, i}
-				<Form.ElementField {form} name="courseIds[{i}]">
-					<Form.Control>
-						{#snippet children({ props })}
-							<input type="hidden" bind:value={$formData.courseIds[i]} {...props} />
-						{/snippet}
-					</Form.Control>
-				</Form.ElementField>
-			{/each}
-		</Form.Fieldset>
-
-		<Form.FormButton disabled={$submitting} loading={$delayed}>
+	<AlertDialog.Root bind:open={dialogOpen}>
+		<AlertDialog.Trigger class={buttonVariants({ variant: 'destructive' })}>
 			Unlink {selectedCourses.length} courses
-			{#snippet loadingMessage()}
-				<span>Unlinking courses...</span>
-			{/snippet}
-		</Form.FormButton>
+		</AlertDialog.Trigger>
+		<AlertDialog.Content>
+			<AlertDialog.Header>
+				<AlertDialog.Title>Unlink {selectedCourses.length} course(s)?</AlertDialog.Title>
+				<AlertDialog.Description>
+					This removes the selected course(s) from this programme. The course(s) themselves are not
+					deleted.
+				</AlertDialog.Description>
+			</AlertDialog.Header>
 
-		<Form.FormError {form} />
-	</form>
+			<form action="?/unlink-courses" method="POST" use:enhance>
+				<input type="text" name="programId" value={program.id} hidden />
+
+				<Form.Fieldset {form} name="courseIds" class="h-0">
+					{#each $formData.courseIds, i}
+						<Form.ElementField {form} name="courseIds[{i}]">
+							<Form.Control>
+								{#snippet children({ props })}
+									<input type="hidden" bind:value={$formData.courseIds[i]} {...props} />
+								{/snippet}
+							</Form.Control>
+						</Form.ElementField>
+					{/each}
+				</Form.Fieldset>
+
+				<Form.FormError {form} />
+
+				<AlertDialog.Footer>
+					<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+					<Form.FormButton
+						type="submit"
+						variant="destructive"
+						disabled={$submitting}
+						loading={$delayed}
+					>
+						Unlink
+						{#snippet loadingMessage()}
+							<span>Unlinking...</span>
+						{/snippet}
+					</Form.FormButton>
+				</AlertDialog.Footer>
+			</form>
+		</AlertDialog.Content>
+	</AlertDialog.Root>
 </div>

--- a/src/routes/graph-editor/programs/[programId=int]/settings/courses/UnlinkCourses.svelte
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/courses/UnlinkCourses.svelte
@@ -64,25 +64,25 @@
 				</AlertDialog.Description>
 			</AlertDialog.Header>
 
-			<form action="?/unlink-courses" method="POST" use:enhance>
-				<input type="text" name="programId" value={program.id} hidden />
+			<Form.FormError {form} />
 
-				<Form.Fieldset {form} name="courseIds" class="h-0">
-					{#each $formData.courseIds, i}
-						<Form.ElementField {form} name="courseIds[{i}]">
-							<Form.Control>
-								{#snippet children({ props })}
-									<input type="hidden" bind:value={$formData.courseIds[i]} {...props} />
-								{/snippet}
-							</Form.Control>
-						</Form.ElementField>
-					{/each}
-				</Form.Fieldset>
+			<AlertDialog.Footer>
+				<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+				<form action="?/unlink-courses" method="POST" use:enhance>
+					<input type="text" name="programId" value={program.id} hidden />
 
-				<Form.FormError {form} />
+					<Form.Fieldset {form} name="courseIds" class="h-0">
+						{#each $formData.courseIds, i}
+							<Form.ElementField {form} name="courseIds[{i}]">
+								<Form.Control>
+									{#snippet children({ props })}
+										<input type="hidden" bind:value={$formData.courseIds[i]} {...props} />
+									{/snippet}
+								</Form.Control>
+							</Form.ElementField>
+						{/each}
+					</Form.Fieldset>
 
-				<AlertDialog.Footer>
-					<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
 					<Form.FormButton
 						type="submit"
 						variant="destructive"
@@ -94,8 +94,8 @@
 							<span>Unlinking...</span>
 						{/snippet}
 					</Form.FormButton>
-				</AlertDialog.Footer>
-			</form>
+				</form>
+			</AlertDialog.Footer>
 		</AlertDialog.Content>
 	</AlertDialog.Root>
 </div>

--- a/src/routes/graph-editor/programs/[programId=int]/settings/courses/course-columns.ts
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/courses/course-columns.ts
@@ -4,7 +4,9 @@ import type { Course } from '@prisma/client';
 import type { ColumnDef } from '@tanstack/table-core';
 import VisitCourse from './VisitCourse.svelte';
 
-export const columns: ColumnDef<Course>[] = [
+export type UnlinkCandidate = Course & { linkable: boolean; reason?: string };
+
+export const columns: ColumnDef<UnlinkCandidate>[] = [
 	{
 		id: 'select',
 		header: ({ table }) =>
@@ -17,6 +19,7 @@ export const columns: ColumnDef<Course>[] = [
 		cell: ({ row }) =>
 			renderComponent(Checkbox, {
 				checked: row.getIsSelected(),
+				disabled: !row.original.linkable,
 				// onCheckedChange: (value) => row.toggleSelected(value),
 				'aria-label': 'Select row'
 			}),
@@ -35,5 +38,10 @@ export const columns: ColumnDef<Course>[] = [
 		id: 'visit',
 		cell: ({ row }) =>
 			renderComponent(VisitCourse, { href: `/graph-editor/courses/${row.original.code}` })
+	},
+	{
+		id: 'reason',
+		header: '',
+		cell: ({ row }) => row.original.reason ?? ''
 	}
 ];


### PR DESCRIPTION
Fixes #141

## Summary
- Unlink table (`CoursesTable`) now disables and dims rows the current user lacks course-level permission on, mirroring the `linkable`/`reason` pattern already used by the link dialog's table. Ineligible courses can no longer be selected via click or checkbox.
- Program settings load now runs an extra `whereHasCoursePermission` query (same helper already used for the link dialog's candidate list and by `CourseActions.linkCourses`) to compute per-course eligibility for the program's linked courses.
- Link dialog (`LinkCourseDataTable`) gains a client-side search input filtering by course name or code over the already permission-filtered candidate list. Pagination and any stale row selection reset when the search text changes.
- Unlink action now requires confirmation: the submit button opens an AlertDialog (confirm/cancel), mirroring the existing `DeleteProgram` pattern, before the unlink request is sent.

What the new `linkable`/`reason` UI does still cover:
- UI/UX parity with the link dialog's existing pattern (this was the issue's literal ask).
- A theoretical race window (user A's page is stale relative to a concurrent change by user B) — but the `linkable` flag is computed once at page load, not live, so it doesn't actually close this window either; the server still rejects with the same generic error as before in that case. Considered, and not worth solving here (very unlikely in practice).
- Defense-in-depth if the permission model changes later (e.g. course-level rights stop auto-inheriting from program membership).

**A dimmed/disabled row is not reachable through normal use under the current permission model.** `whereHasCoursePermission(..., 'CourseAdminEditorORProgramAdminEditor')` grants access to a course via `programs.some.editors`/`admins` — any editor or admin of *any* program the course is linked to. The unlink table itself is only shown to users who already pass `ProgramAdminEditor` on the program being viewed. Since every course in that table is, by definition, linked to that same program, the same relation that gates the table's visibility also always satisfies the per-course check. Verified with a concrete two-user scenario (super admin creates and links a course to a program; a plain editor of that program can still unlink/relink it despite having no relation to the course otherwise) — this is existing, unchanged server-side authorization behavior, not a gap introduced or left by this PR. The `linkable`/`reason` code path is real and correctly wired, it just has no reachable false case today; it only starts doing work if the permission model changes later (see defense-in-depth point above).

## Test plan
- [x] `pnpm check` (svelte-check) — clean
- [x] `pnpm lint` (prettier + eslint) — clean
- [x] `pnpm test` — passing
- [ ] N/A — Manual: as a program editor lacking course-level rights on one linked course, confirm that row is dimmed/disabled with a reason in the unlink table. Not reachable under the current permission model (see explanation above); would require mocked component data or manual DB/code tampering to exercise.
- [x] Manual: confirm unlink still works for fully-permitted courses
- [x] Manual: confirm link dialog search narrows/restores the candidate list correctly across pagination
- [x] Manual: confirm unlinking prompts a confirm/cancel dialog and cancelling leaves the link intact
