### PR TITLE
Fix pin/unpin being unclickable

### DIFF
--- a/src/routes/graph-editor/PinUnpin.svelte
+++ b/src/routes/graph-editor/PinUnpin.svelte
@@ -54,7 +54,9 @@
 						disabled={$submitting}
 						loading={$delayed}
 						onclick={(e) => {
+							e.preventDefault();
 							e.stopPropagation();
+							(e.currentTarget as HTMLButtonElement).form?.requestSubmit();
 						}}
 						onsubmit={(e) => {
 							e.stopPropagation();


### PR DESCRIPTION
This PR fixes a bug where the pin/unpin button in the home page was unclickable (it would jump you to the course page).