### PR TITLE
fix: dedupe super users list by id instead of object reference

### DIFF
--- a/src/routes/graph-editor/courses/+page.svelte
+++ b/src/routes/graph-editor/courses/+page.svelte
@@ -36,6 +36,10 @@
 		open = $state(false);
 	}
 
+	function uniqueById<T extends { id: string }>(items: T[]) {
+		return [...new Map(items.map((item) => [item.id, item])).values()];
+	}
+
 	function generateMailToLink(user: User, course: Course) {
 		const senderName = displayName(data.user);
 		const receiverName = displayName(user);
@@ -86,17 +90,15 @@
 	</div>
 
 	{#each data.courses.filter((course) => !course.isArchived) as course (course.code)}
-		{@const superUsers = Array.from(
-			new Set([
-				...course.admins,
-				...course.editors,
-				...course.programs
-					.map((p) => {
-						return [...p.admins, ...p.editors];
-					})
-					.flat()
-			])
-		)}
+		{@const superUsers = uniqueById([
+			...course.admins,
+			...course.editors,
+			...course.programs
+				.map((p) => {
+					return [...p.admins, ...p.editors];
+				})
+				.flat()
+		])}
 
 		{@const hasAtLeastEditPermission =
 			data.user && hasCoursePermissions(data.user, course, 'CourseAdminEditorORProgramAdminEditor')}
@@ -263,7 +265,7 @@
 				</Table.Row>
 			</Table.Header>
 			<Table.Body>
-				{#each Array.from(new Set(course.programs.map((p) => p.admins).flat())) as user (user.id)}
+				{#each uniqueById(course.programs.map((p) => p.admins).flat()) as user (user.id)}
 					<Table.Row class="bg-purple-100/50 odd:bg-purple-50/50 hover:bg-purple-100/30">
 						<Table.Cell>
 							{displayName(user)}
@@ -289,7 +291,7 @@
 					</Table.Row>
 				{/each}
 
-				{#each Array.from(new Set(course.programs.map((p) => p.editors).flat())) as user (user.id)}
+				{#each uniqueById(course.programs.map((p) => p.editors).flat()) as user (user.id)}
 					<Table.Row class="bg-purple-50/50 odd:bg-purple-100/50 hover:bg-purple-100/30">
 						<Table.Cell>
 							{displayName(user)}
@@ -315,9 +317,7 @@
 					</Table.Row>
 				{/each}
 
-				{#if Array.from(new Set(course.programs
-							.map((p) => [...p.admins, ...p.editors])
-							.flat())).length === 0}
+				{#if uniqueById(course.programs.flatMap((p) => [...p.admins, ...p.editors])).length === 0}
 					<Table.Row>
 						<Table.Cell colspan={3} class="text-center text-gray-500">
 							This course has no programs with admins or editors


### PR DESCRIPTION
## Summary
- Opening the Super Users dialog on the courses page threw a Svelte `each_key_duplicate` error when a user was admin/editor of more than one program on the same course.
- Root cause: dedup used `new Set([...objects])`, which compares by reference. The same user fetched via two different program relations produces two distinct objects with the same `id`, so `Set` doesn't dedupe them and the keyed `{#each ... (user.id)}` block sees a duplicate key.
- Added a `uniqueById` helper that dedupes by `.id` via a `Map`, and applied it everywhere the dialog builds its admin/editor lists (super user count, program admins each-block, program editors each-block, empty-state check).

## Test plan
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm exec prettier --check` on the changed file — passes
- [x] Manually verify: open a course whose parent program has a user with both admin and editor roles (or is admin on multiple programs) across programs, click "Super Users", confirm dialog opens without error and lists the user once per role