### PR TITLE
View counter for the graphs

### DIFF
--- a/prisma/migrations/20260824101500_add_link_view_counts/migration.sql
+++ b/prisma/migrations/20260824101500_add_link_view_counts/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "Link" ADD COLUMN     "viewCount" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE "LinkViewWeek" (
+    "weekStart" DATE NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 0,
+    "linkId" INTEGER NOT NULL,
+
+    CONSTRAINT "LinkViewWeek_pkey" PRIMARY KEY ("linkId","weekStart")
+);
+
+-- AddForeignKey
+ALTER TABLE "LinkViewWeek" ADD CONSTRAINT "LinkViewWeek_linkId_fkey" FOREIGN KEY ("linkId") REFERENCES "Link"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,10 +133,13 @@ model Link {
 	id         Int     @id @default(autoincrement())
 	name       String
 	isArchived Boolean @default(false)
+	viewCount  Int     @default(0) // Running total of public views, denormalized from LinkViewWeek
 
 	course  Course?  @relation("CourseLink", fields: [courseId], references: [id])
 	sandbox Sandbox? @relation("SandboxLink", fields: [sandboxId], references: [id])
 	graph   Graph    @relation("GraphLink", fields: [graphId], references: [id], onDelete: Cascade)
+
+	viewWeeks LinkViewWeek[] @relation("LinkViewWeek")
 
 	parentType ParentType
 	courseId  Int?
@@ -147,6 +150,20 @@ model Link {
 	updatedAt DateTime @updatedAt
 
 	@@unique([courseId, name])
+}
+
+// Aggregate view counts per link per week. Weeks are UTC Monday-start dates, as produced by
+// postgres `date_trunc('week', ...)`. A week in which a link was never viewed has no row at all,
+// so this table only grows for links that are actually used. Holds no visitor information.
+model LinkViewWeek {
+	weekStart DateTime @db.Date
+	count     Int      @default(0)
+
+	link Link @relation("LinkViewWeek", fields: [linkId], references: [id], onDelete: Cascade)
+
+	linkId Int
+
+	@@id([linkId, weekStart])
 }
 
 model Graph {

--- a/src/app.css
+++ b/src/app.css
@@ -91,6 +91,28 @@
 		@apply text-foreground bg-white;
 	}
 
+	/* Scrollbars that do not fight the content: no track at all, faint purple thumb. Used on
+	   scroll areas inside light panels, where the browser default reads as a dark stripe. */
+	.scrollbar-subtle {
+		scrollbar-width: thin;
+		scrollbar-color: var(--color-purple-200) transparent;
+	}
+
+	/* Fallback for browsers without scrollbar-color, which ignore the rule above */
+	.scrollbar-subtle::-webkit-scrollbar {
+		width: 0.5rem;
+		height: 0.5rem;
+	}
+
+	.scrollbar-subtle::-webkit-scrollbar-track {
+		background: transparent;
+	}
+
+	.scrollbar-subtle::-webkit-scrollbar-thumb {
+		border-radius: 9999px;
+		background: var(--color-purple-200);
+	}
+
 	.grain::after {
 		content: '';
 

--- a/src/lib/components/DialogButton.svelte
+++ b/src/lib/components/DialogButton.svelte
@@ -41,6 +41,10 @@
 		children: Snippet;
 		variant?: ButtonVariant;
 		class?: string;
+		/** Extra classes for the dialog itself, e.g. `sm:max-w-4xl` for a dialog that needs more
+		 * room than the default. Note the width has to be set on the `sm:` variant to beat the
+		 * `sm:max-w-lg` the dialog primitive ships with. */
+		contentClass?: string;
 	};
 
 	let {
@@ -53,7 +57,8 @@
 		onclick = () => {},
 		children,
 		variant = 'default',
-		class: classes
+		class: classes,
+		contentClass
 	}: Props = $props();
 </script>
 
@@ -98,7 +103,7 @@
 		{/if}
 	</Dialog.Trigger>
 
-	<Dialog.Content class="max-h-[80dvh] max-w-2xl overflow-y-auto p-0">
+	<Dialog.Content class={cn('max-h-[80dvh] max-w-2xl overflow-y-auto p-0', contentClass)}>
 		<Dialog.Header class="sticky top-0 z-10 bg-white/50 p-4 backdrop-blur-lg">
 			<Dialog.Title class="text-lg">{title}</Dialog.Title>
 			{#if description}

--- a/src/lib/components/DialogButton.svelte
+++ b/src/lib/components/DialogButton.svelte
@@ -4,6 +4,7 @@
 	import {
 		ArrowLeftRight,
 		BadgeHelp,
+		ChartColumn,
 		Code,
 		Copy,
 		Ellipsis,
@@ -16,7 +17,17 @@
 	import { buttonVariants, type ButtonVariant } from './ui/button';
 
 	type Props = {
-		icon?: 'plus' | 'ellipsis' | 'edit' | 'admins' | 'link' | 'help' | 'copy' | 'swap' | 'code';
+		icon?:
+			| 'plus'
+			| 'ellipsis'
+			| 'edit'
+			| 'admins'
+			| 'link'
+			| 'help'
+			| 'copy'
+			| 'swap'
+			| 'code'
+			| 'chart';
 		open?: boolean;
 		button?: string;
 		title: string;
@@ -78,6 +89,8 @@
 			<ArrowLeftRight class="size-5" />
 		{:else if icon == 'code'}
 			<Code class="size-5" />
+		{:else if icon == 'chart'}
+			<ChartColumn class="size-5" />
 		{/if}
 
 		{#if button}

--- a/src/lib/components/graphSettings/GraphTable.svelte
+++ b/src/lib/components/graphSettings/GraphTable.svelte
@@ -100,20 +100,24 @@
 {/if}
 
 <div class="rounded-md border">
-	<Table.Root class="!m-0">
+	<!-- min-width keeps the rows readable on narrow screens: Table.Root's own container scrolls
+	     instead of squeezing the link URL and the action buttons into each other -->
+	<Table.Root class="!m-0 min-w-[42rem]">
 		<Table.Header>
-			<Table.Row>
+			<!-- Rows here are not clickable, so none of them tint on hover. Table.Row ships a hover
+			     tint, which each row cancels by restating its own background for the hover state. -->
+			<Table.Row class="hover:bg-transparent">
 				<Table.Head class="w-full">Name</Table.Head>
 				<Table.Head>Actions</Table.Head>
 			</Table.Row>
 		</Table.Header>
 		<Table.Body>
 			{#each graphs as graph (graph.id)}
-				<Table.Row class="p-0">
+				<Table.Row class="p-0 hover:bg-transparent">
 					<Table.Cell>
 						{graph.name}
 					</Table.Cell>
-					<Table.Cell>
+					<Table.Cell class="flex items-center justify-end gap-1">
 						<CreateLink {graph} {newLinkForm} />
 						<GraphSettings {graph} {editGraphForm} canDelete={hasAtLeastAdminPermission} />
 					</Table.Cell>
@@ -121,7 +125,9 @@
 
 				{#each visibleLinks(graph.links) as link (link.id)}
 					{@const linkAnalytics = analytics.get(link.id)}
-					<Table.Row class="bg-purple-50/50 odd:bg-purple-100/50 hover:bg-purple-100/30">
+					<Table.Row
+						class="bg-purple-50/50 odd:bg-purple-100/50 hover:bg-purple-50/50 odd:hover:bg-purple-100/50"
+					>
 						<Table.Cell class="pl-8 text-xs">
 							<span class="block">{getLinkURL(link)}</span>
 							<span class="mt-1 flex items-center gap-2 text-gray-500">
@@ -147,7 +153,7 @@
 					</Table.Row>
 				{/each}
 			{:else}
-				<Table.Row>
+				<Table.Row class="hover:bg-transparent">
 					<Table.Cell colspan={2} class="text-center">No graphs found.</Table.Cell>
 				</Table.Row>
 			{/each}

--- a/src/lib/components/graphSettings/GraphTable.svelte
+++ b/src/lib/components/graphSettings/GraphTable.svelte
@@ -1,16 +1,27 @@
 <script lang="ts">
+	import { buildLinkAnalytics } from '$lib/utils/linkAnalytics';
+
 	// Components
 	import * as Table from '$lib/components/ui/table/index.js';
+	import { Button } from '$lib/components/ui/button';
 	import GraphSettings from '$lib/components/graphSettings/GraphSettings.svelte';
 	import CreateLink from '$lib/components/graphSettings/CreateLink.svelte';
 	import DeleteLink from '$lib/components/graphSettings/DeleteLink.svelte';
 	import EmbedLink from '$lib/components/graphSettings/EmbedLink.svelte';
+	import LinkAnalytics from '$lib/components/graphSettings/LinkAnalytics.svelte';
+	import StaleLinkBadge from '$lib/components/graphSettings/StaleLinkBadge.svelte';
+
+	// Icons
+	import { Eye } from '@lucide/svelte';
 
 	// Types
 	import type { Prisma, Link } from '@prisma/client';
 	import type { SuperValidated, Infer } from 'sveltekit-superforms';
 	import type { graphSchemaWithId } from '$lib/zod/graphSchema';
 	import type { editLinkSchema, newLinkSchema } from '$lib/zod/linkSchema';
+	import type { LinkViewWeek } from '$lib/utils/linkAnalytics';
+
+	type StaleFilter = 'all' | 'only-stale' | 'hide-stale';
 
 	type GraphLinksProps = {
 		graphs: Prisma.GraphGetPayload<{
@@ -24,6 +35,7 @@
 		editLinkForm: SuperValidated<Infer<typeof editLinkSchema>>;
 		getLinkURL: (link: Link) => string;
 		hasAtLeastAdminPermission: boolean;
+		linkViews: LinkViewWeek[];
 	};
 
 	const {
@@ -32,9 +44,60 @@
 		newLinkForm,
 		editLinkForm,
 		getLinkURL,
-		hasAtLeastAdminPermission
+		hasAtLeastAdminPermission,
+		linkViews
 	}: GraphLinksProps = $props();
+
+	const filters: { value: StaleFilter; label: string }[] = [
+		{ value: 'all', label: 'All links' },
+		{ value: 'only-stale', label: 'Only stale' },
+		{ value: 'hide-stale', label: 'Hide stale' }
+	];
+
+	let staleFilter = $state<StaleFilter>('all');
+
+	const analytics = $derived(
+		buildLinkAnalytics(
+			graphs.flatMap((graph) => graph.links),
+			linkViews
+		)
+	);
+
+	const staleCount = $derived([...analytics.values()].filter((views) => views.isStale).length);
+
+	/** The links of one graph, minus the ones the stale filter hides. Runs on data that is already
+	 * loaded, so switching the filter costs no query. */
+	function visibleLinks(links: Link[]) {
+		if (staleFilter === 'all') return links;
+
+		return links.filter((link) => {
+			const isStale = analytics.get(link.id)?.isStale ?? false;
+			return staleFilter === 'only-stale' ? isStale : !isStale;
+		});
+	}
 </script>
+
+{#if analytics.size > 0}
+	<div class="mb-2 flex flex-wrap items-center justify-between gap-2">
+		<p class="!m-0 text-sm text-gray-500">
+			{staleCount} of {analytics.size}
+			{analytics.size == 1 ? 'link is' : 'links are'} stale
+		</p>
+
+		<div class="flex items-center gap-1">
+			{#each filters as filter (filter.value)}
+				<Button
+					size="sm"
+					variant={staleFilter == filter.value ? 'default' : 'outline'}
+					aria-pressed={staleFilter == filter.value}
+					onclick={() => (staleFilter = filter.value)}
+				>
+					{filter.label}
+				</Button>
+			{/each}
+		</div>
+	</div>
+{/if}
 
 <div class="rounded-md border">
 	<Table.Root class="!m-0">
@@ -56,12 +119,26 @@
 					</Table.Cell>
 				</Table.Row>
 
-				{#each graph.links as link (link.id)}
+				{#each visibleLinks(graph.links) as link (link.id)}
+					{@const linkAnalytics = analytics.get(link.id)}
 					<Table.Row class="bg-purple-50/50 odd:bg-purple-100/50 hover:bg-purple-100/30">
 						<Table.Cell class="pl-8 text-xs">
-							{getLinkURL(link)}
+							<span class="block">{getLinkURL(link)}</span>
+							<span class="mt-1 flex items-center gap-2 text-gray-500">
+								<span class="flex items-center gap-1">
+									<Eye class="size-3.5" />
+									{link.viewCount}
+									{link.viewCount == 1 ? 'view' : 'views'}
+								</span>
+								{#if linkAnalytics?.isStale}
+									<StaleLinkBadge analytics={linkAnalytics} />
+								{/if}
+							</span>
 						</Table.Cell>
 						<Table.Cell class="flex items-center justify-end gap-1">
+							{#if linkAnalytics}
+								<LinkAnalytics {link} analytics={linkAnalytics} url={getLinkURL(link)} />
+							{/if}
 							<EmbedLink {link} {getLinkURL} lectures={graph.lectures} />
 							{#if hasAtLeastAdminPermission}
 								<DeleteLink {graph} {link} {editLinkForm} />

--- a/src/lib/components/graphSettings/LinkAnalytics.svelte
+++ b/src/lib/components/graphSettings/LinkAnalytics.svelte
@@ -32,6 +32,7 @@
 	button="Analytics"
 	title="Views of {link.name}"
 	description={url}
+	contentClass="sm:max-w-4xl scrollbar-subtle"
 >
 	<div class="space-y-4">
 		<div class="grid grid-cols-2 gap-2">
@@ -57,17 +58,17 @@
 		<LinkViewsChart weeks={analytics.weeks} />
 
 		{#if weeksWithViews.length > 0}
-			<div class="max-h-56 overflow-y-auto rounded-md border">
+			<div class="scrollbar-subtle max-h-56 overflow-y-auto rounded-md border">
 				<Table.Root class="!m-0">
 					<Table.Header>
-						<Table.Row>
+						<Table.Row class="hover:bg-transparent">
 							<Table.Head class="w-full">Week</Table.Head>
 							<Table.Head class="text-right">Views</Table.Head>
 						</Table.Row>
 					</Table.Header>
 					<Table.Body>
 						{#each weeksWithViews as week (week.weekStart.getTime())}
-							<Table.Row>
+							<Table.Row class="hover:bg-transparent">
 								<Table.Cell class="text-xs">{formatAcademicWeekLong(week.weekStart)}</Table.Cell>
 								<Table.Cell class="text-right tabular-nums">{week.count}</Table.Cell>
 							</Table.Row>

--- a/src/lib/components/graphSettings/LinkAnalytics.svelte
+++ b/src/lib/components/graphSettings/LinkAnalytics.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { formatAcademicWeekLong } from '$lib/utils/academicWeeks';
+
+	// Components
+	import * as Table from '$lib/components/ui/table/index.js';
+	import DialogButton from '$lib/components/DialogButton.svelte';
+	import LinkViewsChart from '$lib/components/graphSettings/LinkViewsChart.svelte';
+
+	// Types
+	import type { Link } from '@prisma/client';
+	import type { LinkAnalytics } from '$lib/utils/linkAnalytics';
+
+	type LinkAnalyticsProps = {
+		link: Link;
+		analytics: LinkAnalytics;
+		url: string;
+	};
+
+	const { link, analytics, url }: LinkAnalyticsProps = $props();
+
+	/** Only the weeks that actually have views, newest first. Carries the same numbers as the
+	 * chart, for anyone who would rather read them than look at bars. */
+	const weeksWithViews = $derived([...analytics.weeks.filter((week) => week.count > 0)].reverse());
+
+	let dialogOpen = $state(false);
+</script>
+
+<DialogButton
+	bind:open={dialogOpen}
+	icon="chart"
+	variant="outline"
+	button="Analytics"
+	title="Views of {link.name}"
+	description={url}
+>
+	<div class="space-y-4">
+		<div class="grid grid-cols-2 gap-2">
+			<div class="rounded-md border p-3">
+				<p class="text-sm text-gray-500">Total views</p>
+				<p class="text-3xl font-semibold text-purple-950">{analytics.total}</p>
+				<p class="text-xs text-gray-400">Since this link was created</p>
+			</div>
+
+			<div class="rounded-md border p-3">
+				<p class="text-sm text-gray-500">Last {analytics.windowWeeks} weeks</p>
+				<p class="text-3xl font-semibold text-purple-950">{analytics.recentViews}</p>
+				{#if analytics.isStale}
+					<p class="text-xs text-amber-700">
+						Under the stale threshold of {analytics.threshold}
+					</p>
+				{:else}
+					<p class="text-xs text-gray-400">Stale below {analytics.threshold}</p>
+				{/if}
+			</div>
+		</div>
+
+		<LinkViewsChart weeks={analytics.weeks} />
+
+		{#if weeksWithViews.length > 0}
+			<div class="max-h-56 overflow-y-auto rounded-md border">
+				<Table.Root class="!m-0">
+					<Table.Header>
+						<Table.Row>
+							<Table.Head class="w-full">Week</Table.Head>
+							<Table.Head class="text-right">Views</Table.Head>
+						</Table.Row>
+					</Table.Header>
+					<Table.Body>
+						{#each weeksWithViews as week (week.weekStart.getTime())}
+							<Table.Row>
+								<Table.Cell class="text-xs">{formatAcademicWeekLong(week.weekStart)}</Table.Cell>
+								<Table.Cell class="text-right tabular-nums">{week.count}</Table.Cell>
+							</Table.Row>
+						{/each}
+					</Table.Body>
+				</Table.Root>
+			</div>
+		{/if}
+
+		<p class="text-xs text-gray-400">
+			Views are counted per visit of the public link, without recording anything about who visited.
+			Opening a graph from the graph editor is not counted.
+		</p>
+	</div>
+</DialogButton>

--- a/src/lib/components/graphSettings/LinkViewsChart.svelte
+++ b/src/lib/components/graphSettings/LinkViewsChart.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import { formatAcademicWeek, formatAcademicWeekLong } from '$lib/utils/academicWeeks';
+
+	// Types
+	import type { ViewWeek } from '$lib/utils/linkAnalytics';
+
+	type LinkViewsChartProps = {
+		/** Dense week series, oldest first, weeks without views included as zeroes */
+		weeks: ViewWeek[];
+	};
+
+	const { weeks }: LinkViewsChartProps = $props();
+
+	/** Label every 8th week, offset from the edges so no label hangs off the chart */
+	const LABEL_EVERY = 8;
+	const LABEL_OFFSET = 2;
+
+	let hovered = $state<number | null>(null);
+
+	const peak = $derived(
+		weeks.reduce(
+			(best, week) => (week.count > best.count ? week : best),
+			weeks[0] ?? { weekStart: new Date(0), count: 0 }
+		)
+	);
+
+	/** Top of the scale, rounded up to the next half order of magnitude so it reads as a round
+	 * number rather than as the exact peak. */
+	const top = $derived.by(() => {
+		if (peak.count <= 2) return 2;
+
+		const step = 10 ** Math.floor(Math.log10(peak.count)) / 2;
+		return Math.ceil(peak.count / step) * step;
+	});
+
+	const ticks = $derived([
+		{ height: 100, label: `${top}` },
+		{ height: 50, label: '' },
+		{ height: 0, label: '0' }
+	]);
+
+	const readout = $derived.by(() => {
+		if (hovered != null) {
+			const week = weeks[hovered];
+			const views = week.count === 1 ? '1 view' : `${week.count} views`;
+			return `${formatAcademicWeekLong(week.weekStart)}: ${views}`;
+		}
+
+		if (peak.count === 0) return `No views in the last ${weeks.length} weeks`;
+		return `Busiest week: ${peak.count} views in ${formatAcademicWeekLong(peak.weekStart)}`;
+	});
+</script>
+
+<figure class="!m-0 space-y-2">
+	<figcaption class="text-sm text-gray-500">Views per week, last {weeks.length} weeks</figcaption>
+
+	<p class="text-primary min-h-10 text-sm">{readout}</p>
+
+	<div class="relative h-40 pl-8">
+		<!-- Scale: a labelled top and baseline, with a hairline halfway between -->
+		{#each ticks as tick (tick.height)}
+			<div
+				class="pointer-events-none absolute inset-x-0 flex -translate-y-1/2 items-center gap-1"
+				style="top: {100 - tick.height}%"
+			>
+				<span class="w-7 shrink-0 text-right text-[10px] text-gray-400 tabular-nums">
+					{tick.label}
+				</span>
+				<div class="h-px grow bg-gray-200"></div>
+			</div>
+		{/each}
+
+		<div class="relative flex h-full gap-[2px]">
+			{#each weeks as week, index (week.weekStart.getTime())}
+				<button
+					type="button"
+					class="relative h-full min-w-0 grow rounded-t transition-colors hover:bg-purple-100/70 focus-visible:bg-purple-100/70 focus-visible:outline-none"
+					tabindex={week.count > 0 ? 0 : -1}
+					aria-label="{formatAcademicWeekLong(week.weekStart)}: {week.count} views"
+					onmouseenter={() => (hovered = index)}
+					onmouseleave={() => (hovered = null)}
+					onfocus={() => (hovered = index)}
+					onblur={() => (hovered = null)}
+				>
+					{#if week.count > 0}
+						<span
+							class="bg-primary absolute bottom-0 left-1/2 w-full max-w-6 -translate-x-1/2 rounded-t-[4px]"
+							style="height: max(2px, {(week.count / top) * 100}%)"
+						></span>
+					{/if}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	<div class="flex gap-[2px] pl-8">
+		{#each weeks as week, index (week.weekStart.getTime())}
+			<span class="min-w-0 grow text-center text-[10px] whitespace-nowrap text-gray-400">
+				{index % LABEL_EVERY === LABEL_OFFSET ? formatAcademicWeek(week.weekStart) : ''}
+			</span>
+		{/each}
+	</div>
+
+	<p class="text-xs text-gray-400">
+		Weeks are TU Delft academic weeks, week 1 being the week that contains September 1st.
+	</p>
+</figure>

--- a/src/lib/components/graphSettings/StaleLinkBadge.svelte
+++ b/src/lib/components/graphSettings/StaleLinkBadge.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	// Components
+	import * as Popover from '$lib/components/ui/popover';
+
+	// Icons
+	import { TrendingDown } from '@lucide/svelte';
+
+	// Types
+	import type { LinkAnalytics } from '$lib/utils/linkAnalytics';
+
+	type StaleLinkBadgeProps = {
+		analytics: LinkAnalytics;
+	};
+
+	const { analytics }: StaleLinkBadgeProps = $props();
+
+	const views = $derived(analytics.recentViews === 1 ? '1 view' : `${analytics.recentViews} views`);
+</script>
+
+<Popover.Root>
+	<Popover.Trigger
+		class="flex items-center gap-1 rounded border border-dashed border-amber-600 bg-amber-50 px-1.5 py-0.5 text-xs text-amber-800 hover:bg-amber-100"
+	>
+		<TrendingDown class="size-3.5" />
+		<span>Stale</span>
+	</Popover.Trigger>
+	<Popover.Content class="w-80 space-y-1 text-sm">
+		<p class="font-bold">Hardly used lately</p>
+		<p>
+			This link got {views} in the last {analytics.windowWeeks} weeks. Anything under {analytics.threshold}
+			views in that period is marked stale.
+		</p>
+		<p class="text-gray-500">
+			Nothing happens to a stale link, it keeps working. It is only flagged here so you can decide
+			whether to keep sharing it.
+		</p>
+	</Popover.Content>
+</Popover.Root>

--- a/src/lib/server/actions/LinkViews.ts
+++ b/src/lib/server/actions/LinkViews.ts
@@ -1,0 +1,67 @@
+import prisma from '$lib/server/db/prisma';
+import { STALE_LINK_WINDOW_WEEKS } from '$lib/settings';
+import { addWeeks, utcWeekStart } from '$lib/utils/academicWeeks';
+
+import type { LinkViewWeek } from '$lib/utils/linkAnalytics';
+
+/** Aggregate view counting for shareable graph links. Records a view when the public graph
+ * viewer serves a graph through a link, and reads back the weekly buckets the graph-editor's
+ * link list shows. Deliberately stores nothing about who viewed: no ip, no session, no user. */
+export class LinkViewActions {
+	/**
+	 * Record one view of a link: bump the current week's bucket and the link's running total.
+	 *
+	 * Both writes are one statement each so concurrent views cannot lose a count, and the week
+	 * boundary comes from postgres `date_trunc('week', ...)` so every bucket lands on the same
+	 * UTC Monday regardless of where the app runs.
+	 *
+	 * Never throws. Callers on the render path must not await this, so a failure has nowhere to
+	 * surface but the log.
+	 *
+	 * @param linkId - The link the visitor came in through
+	 */
+	static async recordView(linkId: number): Promise<void> {
+		try {
+			await prisma.$transaction([
+				prisma.$executeRaw`
+					INSERT INTO "LinkViewWeek" ("linkId", "weekStart", "count")
+					VALUES (${linkId}, date_trunc('week', now() AT TIME ZONE 'utc')::date, 1)
+					ON CONFLICT ("linkId", "weekStart")
+					DO UPDATE SET "count" = "LinkViewWeek"."count" + 1
+				`,
+				prisma.link.update({
+					where: { id: linkId },
+					data: { viewCount: { increment: 1 } }
+				})
+			]);
+		} catch (e: unknown) {
+			// A view that goes uncounted is not worth failing a page render over
+			console.error(`Failed to record a view for link ${linkId}:`, e);
+		}
+	}
+
+	/**
+	 * Read the weekly view buckets of a set of links, over the trailing staleness window.
+	 *
+	 * Callers are expected to have resolved the link ids through a permission-checked query
+	 * already: seeing a link's analytics needs no more access than seeing the link.
+	 *
+	 * @param linkIds - Links to read buckets for
+	 * @param now - The moment the trailing window ends, defaults to the current time
+	 * @returns Buckets for those links, oldest week first. Weeks without views have no bucket.
+	 */
+	static async getWeeklyViews(linkIds: number[], now: Date = new Date()): Promise<LinkViewWeek[]> {
+		if (linkIds.length === 0) return [];
+
+		const windowStart = addWeeks(utcWeekStart(now), -(STALE_LINK_WINDOW_WEEKS - 1));
+
+		return prisma.linkViewWeek.findMany({
+			where: {
+				linkId: { in: linkIds },
+				weekStart: { gte: windowStart }
+			},
+			select: { linkId: true, weekStart: true, count: true },
+			orderBy: { weekStart: 'asc' }
+		});
+	}
+}

--- a/src/lib/server/actions/tests/linkViews.test.ts
+++ b/src/lib/server/actions/tests/linkViews.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import prisma from '$lib/server/db/prisma';
+import { LinkViewActions } from '$lib/server/actions/LinkViews';
+import { STALE_LINK_VIEW_THRESHOLD, STALE_LINK_WINDOW_WEEKS } from '$lib/settings';
+import { addWeeks, utcWeekStart } from '$lib/utils/academicWeeks';
+import { buildLinkAnalytics } from '$lib/utils/linkAnalytics';
+import { FIXTURE_COURSES, FIXTURE_GRAPHS } from './helpers/fixture';
+
+/** Create a link on the fixture's first graph. Each test uses its own name, since the fixture is
+ * only reseeded between files. */
+async function makeLink(name: string) {
+	const graph = await prisma.graph.findFirstOrThrow({
+		where: { name: FIXTURE_GRAPHS.one, course: { code: FIXTURE_COURSES.one.code } }
+	});
+
+	return prisma.link.create({
+		data: { name, graphId: graph.id, parentType: 'COURSE', courseId: graph.courseId }
+	});
+}
+
+describe('LinkViewActions.recordView', () => {
+	it('starts a link off at zero views with no buckets', async () => {
+		const link = await makeLink('views-fresh');
+
+		expect(link.viewCount).toBe(0);
+		expect(await prisma.linkViewWeek.count({ where: { linkId: link.id } })).toBe(0);
+	});
+
+	it('bumps the running total and the current week bucket', async () => {
+		const link = await makeLink('views-counted');
+
+		await LinkViewActions.recordView(link.id);
+		await LinkViewActions.recordView(link.id);
+		await LinkViewActions.recordView(link.id);
+
+		const updated = await prisma.link.findUniqueOrThrow({ where: { id: link.id } });
+		expect(updated.viewCount).toBe(3);
+
+		const buckets = await prisma.linkViewWeek.findMany({ where: { linkId: link.id } });
+		expect(buckets).toHaveLength(1);
+		expect(buckets[0].count).toBe(3);
+	});
+
+	it('buckets on the UTC Monday of the current week', async () => {
+		const link = await makeLink('views-week-start');
+
+		await LinkViewActions.recordView(link.id);
+
+		const bucket = await prisma.linkViewWeek.findFirstOrThrow({ where: { linkId: link.id } });
+		expect(bucket.weekStart).toEqual(utcWeekStart(new Date()));
+	});
+
+	it('keeps the counts of different links apart', async () => {
+		const one = await makeLink('views-split-one');
+		const two = await makeLink('views-split-two');
+
+		await LinkViewActions.recordView(one.id);
+		await LinkViewActions.recordView(two.id);
+		await LinkViewActions.recordView(two.id);
+
+		expect((await prisma.link.findUniqueOrThrow({ where: { id: one.id } })).viewCount).toBe(1);
+		expect((await prisma.link.findUniqueOrThrow({ where: { id: two.id } })).viewCount).toBe(2);
+	});
+
+	it('swallows a failed write instead of throwing, and writes nothing', async () => {
+		const before = await prisma.linkViewWeek.count();
+
+		await expect(LinkViewActions.recordView(-1)).resolves.toBeUndefined();
+
+		expect(await prisma.linkViewWeek.count()).toBe(before);
+	});
+});
+
+describe('LinkViewActions.getWeeklyViews', () => {
+	it('reads back the buckets inside the window and skips the ones before it', async () => {
+		const link = await makeLink('views-window');
+		const currentWeek = utcWeekStart(new Date());
+		const oldestInWindow = addWeeks(currentWeek, -(STALE_LINK_WINDOW_WEEKS - 1));
+
+		await prisma.linkViewWeek.createMany({
+			data: [
+				{ linkId: link.id, weekStart: oldestInWindow, count: 4 },
+				{ linkId: link.id, weekStart: addWeeks(currentWeek, -STALE_LINK_WINDOW_WEEKS), count: 9 }
+			]
+		});
+
+		expect(await LinkViewActions.getWeeklyViews([link.id])).toEqual([
+			{ linkId: link.id, weekStart: oldestInWindow, count: 4 }
+		]);
+	});
+
+	it('reads nothing when asked about no links', async () => {
+		expect(await LinkViewActions.getWeeklyViews([])).toEqual([]);
+	});
+
+	it('feeds staleness, which stays derived from the buckets that were read', async () => {
+		const stale = await makeLink('views-stale');
+		const busy = await makeLink('views-busy');
+		const currentWeek = utcWeekStart(new Date());
+
+		await prisma.linkViewWeek.createMany({
+			data: [
+				// Plenty of views, but all of them from before the window
+				{
+					linkId: stale.id,
+					weekStart: addWeeks(currentWeek, -STALE_LINK_WINDOW_WEEKS),
+					count: STALE_LINK_VIEW_THRESHOLD * 10
+				},
+				{ linkId: busy.id, weekStart: currentWeek, count: STALE_LINK_VIEW_THRESHOLD }
+			]
+		});
+		await prisma.link.update({
+			where: { id: stale.id },
+			data: { viewCount: STALE_LINK_VIEW_THRESHOLD * 10 }
+		});
+
+		const buckets = await LinkViewActions.getWeeklyViews([stale.id, busy.id]);
+		const analytics = buildLinkAnalytics(
+			[
+				{ id: stale.id, viewCount: STALE_LINK_VIEW_THRESHOLD * 10 },
+				{ id: busy.id, viewCount: STALE_LINK_VIEW_THRESHOLD }
+			],
+			buckets
+		);
+
+		expect(analytics.get(stale.id)?.isStale).toBe(true);
+		expect(analytics.get(stale.id)?.recentViews).toBe(0);
+		expect(analytics.get(busy.id)?.isStale).toBe(false);
+	});
+});

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -16,6 +16,12 @@ export const MAX_COURSE_NAME_LENGTH = 30;
 export const MAX_GRAPH_NAME_LENGTH = 50;
 export const MAX_LINK_NAME_LENGTH = 12;
 
+// Link analytics settings
+// A link is called stale when it collected fewer than STALE_LINK_VIEW_THRESHOLD views over the
+// trailing STALE_LINK_WINDOW_WEEKS weeks (the current week plus the ones before it).
+export const STALE_LINK_WINDOW_WEEKS = 52;
+export const STALE_LINK_VIEW_THRESHOLD = 10;
+
 // Domain settings
 export const MAX_DOMAIN_NAME_LENGTH = 50;
 

--- a/src/lib/utils/academicWeeks.test.ts
+++ b/src/lib/utils/academicWeeks.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+	academicWeek,
+	addWeeks,
+	formatAcademicWeek,
+	formatAcademicWeekLong,
+	utcWeekStart
+} from './academicWeeks';
+
+describe('utcWeekStart', () => {
+	it('keeps a Monday where it is', () => {
+		// 1 September 2025 is a Monday
+		expect(utcWeekStart(new Date('2025-09-01T00:00:00Z')).toISOString()).toBe(
+			'2025-09-01T00:00:00.000Z'
+		);
+	});
+
+	it('snaps a Sunday back to the Monday before it', () => {
+		expect(utcWeekStart(new Date('2024-09-01T23:59:59Z')).toISOString()).toBe(
+			'2024-08-26T00:00:00.000Z'
+		);
+	});
+
+	it('drops the time of day', () => {
+		expect(utcWeekStart(new Date('2025-09-04T13:45:12.345Z')).toISOString()).toBe(
+			'2025-09-01T00:00:00.000Z'
+		);
+	});
+});
+
+describe('addWeeks', () => {
+	it('shifts forwards and backwards by whole weeks', () => {
+		const week = utcWeekStart(new Date('2025-09-01T00:00:00Z'));
+
+		expect(addWeeks(week, 2).toISOString()).toBe('2025-09-15T00:00:00.000Z');
+		expect(addWeeks(week, -1).toISOString()).toBe('2025-08-25T00:00:00.000Z');
+	});
+});
+
+describe('academicWeek', () => {
+	it('numbers the week containing September 1st as week 1', () => {
+		// 1 September 2025 is itself a Monday
+		expect(academicWeek(new Date('2025-09-01T00:00:00Z'))).toEqual({ year: 2025, week: 1 });
+
+		// 1 September 2024 is a Sunday, so academic week 1 starts on 26 August 2024
+		expect(academicWeek(new Date('2024-08-26T00:00:00Z'))).toEqual({ year: 2024, week: 1 });
+		expect(academicWeek(new Date('2024-09-02T00:00:00Z'))).toEqual({ year: 2024, week: 2 });
+	});
+
+	it('counts on through the academic year', () => {
+		expect(academicWeek(new Date('2025-12-22T00:00:00Z'))).toEqual({ year: 2025, week: 17 });
+	});
+
+	it('puts a week before September 1st in the previous academic year', () => {
+		expect(academicWeek(new Date('2024-08-19T00:00:00Z'))).toEqual({ year: 2023, week: 52 });
+	});
+
+	it('accepts any moment in the week, not just its start', () => {
+		expect(academicWeek(new Date('2025-09-07T18:00:00Z'))).toEqual({ year: 2025, week: 1 });
+	});
+});
+
+describe('formatAcademicWeek', () => {
+	it('gives a short axis label', () => {
+		expect(formatAcademicWeek(new Date('2025-09-15T00:00:00Z'))).toBe('W3');
+	});
+
+	it('gives a long label naming the academic year and the start date', () => {
+		expect(formatAcademicWeekLong(new Date('2025-09-15T00:00:00Z'))).toBe(
+			'Week 3 of 2025/2026, from 15 Sep 2025'
+		);
+	});
+});

--- a/src/lib/utils/academicWeeks.ts
+++ b/src/lib/utils/academicWeeks.ts
@@ -1,0 +1,107 @@
+/**
+ * Week math for link view analytics.
+ *
+ * Storage keeps view buckets on plain UTC Monday-start weeks (what postgres
+ * `date_trunc('week', ...)` produces). Everything in here is presentation: turning such a week
+ * start into the TU Delft academic week numbering, where week 1 is the week containing
+ * September 1st. Nothing here is stored.
+ */
+
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+/** September, zero-indexed for Date.UTC */
+const SEPTEMBER = 8;
+
+/** Month names are spelled out here rather than taken from toLocaleDateString, so a label reads
+ * the same no matter which locale data the server and the browser happen to ship. */
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/** An academic week: the calendar year the academic year starts in, plus the week number in it. */
+export type AcademicWeek = {
+	/** Calendar year the academic year started in, so 2025 means the 2025/2026 academic year */
+	year: number;
+	/** 1-based week number, week 1 being the week that contains September 1st */
+	week: number;
+};
+
+/**
+ * Snap a moment to the start of its UTC week, Monday 00:00:00.000 UTC. Mirrors what
+ * `date_trunc('week', ...)` does in postgres, so a JS-side week start and a stored week start
+ * are the same value.
+ *
+ * @param date - Any moment
+ * @returns A new Date at Monday 00:00 UTC of the week containing `date`
+ */
+export function utcWeekStart(date: Date): Date {
+	const weekStart = new Date(
+		Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+	);
+
+	// getUTCDay() is 0 for Sunday, which is 6 days into a Monday-start week
+	const daysSinceMonday = (weekStart.getUTCDay() + 6) % 7;
+	weekStart.setUTCDate(weekStart.getUTCDate() - daysSinceMonday);
+
+	return weekStart;
+}
+
+/**
+ * Shift a week start by a whole number of weeks.
+ *
+ * @param weekStart - A week start, as returned by utcWeekStart
+ * @param weeks - Number of weeks to add, may be negative
+ * @returns A new Date, `weeks` weeks after `weekStart`
+ */
+export function addWeeks(weekStart: Date, weeks: number): Date {
+	return new Date(weekStart.getTime() + weeks * MS_PER_WEEK);
+}
+
+/**
+ * The first week of an academic year: the UTC week containing September 1st of that year.
+ *
+ * @param year - Calendar year the academic year starts in
+ * @returns The week start of academic week 1
+ */
+function academicYearStart(year: number): Date {
+	return utcWeekStart(new Date(Date.UTC(year, SEPTEMBER, 1)));
+}
+
+/**
+ * Convert a UTC week start into TU Delft academic week numbering.
+ *
+ * @param weekStart - A week start, as returned by utcWeekStart
+ * @returns The academic year and 1-based week number that week falls in
+ */
+export function academicWeek(weekStart: Date): AcademicWeek {
+	const start = utcWeekStart(weekStart);
+
+	let year = start.getUTCFullYear();
+	if (start.getTime() < academicYearStart(year).getTime()) year -= 1;
+
+	const week = Math.round((start.getTime() - academicYearStart(year).getTime()) / MS_PER_WEEK) + 1;
+
+	return { year, week };
+}
+
+/**
+ * Short academic week label, for a chart axis or a table cell.
+ *
+ * @param weekStart - A week start, as returned by utcWeekStart
+ * @returns A label like `W3`
+ */
+export function formatAcademicWeek(weekStart: Date): string {
+	return `W${academicWeek(weekStart).week}`;
+}
+
+/**
+ * Full academic week label, naming the academic year and the calendar date the week starts on.
+ *
+ * @param weekStart - A week start, as returned by utcWeekStart
+ * @returns A label like `Week 3 of 2025/2026, from 15 Sep 2025`
+ */
+export function formatAcademicWeekLong(weekStart: Date): string {
+	const { year, week } = academicWeek(weekStart);
+	const start = utcWeekStart(weekStart);
+	const date = `${start.getUTCDate()} ${MONTHS[start.getUTCMonth()]} ${start.getUTCFullYear()}`;
+
+	return `Week ${week} of ${year}/${year + 1}, from ${date}`;
+}

--- a/src/lib/utils/linkAnalytics.test.ts
+++ b/src/lib/utils/linkAnalytics.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { STALE_LINK_VIEW_THRESHOLD, STALE_LINK_WINDOW_WEEKS } from '$lib/settings';
+import { buildLinkAnalytics, type LinkViewWeek } from './linkAnalytics';
+import { addWeeks, utcWeekStart } from './academicWeeks';
+
+const NOW = new Date('2026-02-11T10:30:00Z');
+const CURRENT_WEEK = utcWeekStart(NOW);
+
+/** A bucket `weeksAgo` weeks before the week containing NOW */
+function bucket(linkId: number, weeksAgo: number, count: number): LinkViewWeek {
+	return { linkId, weekStart: addWeeks(CURRENT_WEEK, -weeksAgo), count };
+}
+
+describe('buildLinkAnalytics', () => {
+	it('takes the total from the link, not from the buckets', () => {
+		const analytics = buildLinkAnalytics([{ id: 1, viewCount: 900 }], [bucket(1, 0, 3)], NOW);
+
+		expect(analytics.get(1)?.total).toBe(900);
+		expect(analytics.get(1)?.recentViews).toBe(3);
+	});
+
+	it('returns one dense week per window week, oldest first, zeroes included', () => {
+		const analytics = buildLinkAnalytics([{ id: 1, viewCount: 2 }], [bucket(1, 3, 2)], NOW);
+		const weeks = analytics.get(1)!.weeks;
+
+		expect(weeks).toHaveLength(STALE_LINK_WINDOW_WEEKS);
+		expect(weeks[0].weekStart).toEqual(addWeeks(CURRENT_WEEK, -(STALE_LINK_WINDOW_WEEKS - 1)));
+		expect(weeks.at(-1)?.weekStart).toEqual(CURRENT_WEEK);
+
+		// Only the week that has a bucket is non-zero
+		expect(weeks.filter((week) => week.count > 0)).toEqual([
+			{ weekStart: addWeeks(CURRENT_WEEK, -3), count: 2 }
+		]);
+	});
+
+	it('counts the oldest week of the window but not the one before it', () => {
+		const analytics = buildLinkAnalytics(
+			[{ id: 1, viewCount: 5 }],
+			[bucket(1, STALE_LINK_WINDOW_WEEKS - 1, 2), bucket(1, STALE_LINK_WINDOW_WEEKS, 3)],
+			NOW
+		);
+
+		expect(analytics.get(1)?.recentViews).toBe(2);
+	});
+
+	it('keeps buckets of different links apart', () => {
+		const analytics = buildLinkAnalytics(
+			[
+				{ id: 1, viewCount: 4 },
+				{ id: 2, viewCount: 7 }
+			],
+			[bucket(1, 0, 4), bucket(2, 1, 7)],
+			NOW
+		);
+
+		expect(analytics.get(1)?.recentViews).toBe(4);
+		expect(analytics.get(2)?.recentViews).toBe(7);
+	});
+
+	it('marks a link stale below the threshold and not stale at it', () => {
+		const analytics = buildLinkAnalytics(
+			[
+				{ id: 1, viewCount: 100 },
+				{ id: 2, viewCount: 100 }
+			],
+			[
+				bucket(1, 1, STALE_LINK_VIEW_THRESHOLD - 1),
+				bucket(2, 1, STALE_LINK_VIEW_THRESHOLD - 1),
+				bucket(2, 2, 1)
+			],
+			NOW
+		);
+
+		expect(analytics.get(1)?.isStale).toBe(true);
+		expect(analytics.get(2)?.isStale).toBe(false);
+	});
+
+	it('counts a link with no buckets at all as stale, with an all-zero series', () => {
+		const analytics = buildLinkAnalytics([{ id: 1, viewCount: 0 }], [], NOW);
+
+		expect(analytics.get(1)?.recentViews).toBe(0);
+		expect(analytics.get(1)?.isStale).toBe(true);
+		expect(analytics.get(1)?.weeks.every((week) => week.count === 0)).toBe(true);
+	});
+
+	it('ignores buckets belonging to links it was not asked about', () => {
+		const analytics = buildLinkAnalytics([{ id: 1, viewCount: 1 }], [bucket(2, 0, 50)], NOW);
+
+		expect(analytics.size).toBe(1);
+		expect(analytics.get(1)?.recentViews).toBe(0);
+	});
+
+	it('reports the window and threshold it used', () => {
+		const analytics = buildLinkAnalytics([{ id: 1, viewCount: 0 }], [], NOW);
+
+		expect(analytics.get(1)?.windowWeeks).toBe(STALE_LINK_WINDOW_WEEKS);
+		expect(analytics.get(1)?.threshold).toBe(STALE_LINK_VIEW_THRESHOLD);
+	});
+});

--- a/src/lib/utils/linkAnalytics.ts
+++ b/src/lib/utils/linkAnalytics.ts
@@ -1,0 +1,93 @@
+import { STALE_LINK_VIEW_THRESHOLD, STALE_LINK_WINDOW_WEEKS } from '$lib/settings';
+import { addWeeks, utcWeekStart } from './academicWeeks';
+
+/** One stored bucket: how often one link was viewed during one UTC Monday-start week. */
+export type LinkViewWeek = {
+	linkId: number;
+	weekStart: Date;
+	count: number;
+};
+
+/** One week of a chart series. Unlike a stored bucket, a week with no views is present as 0. */
+export type ViewWeek = {
+	weekStart: Date;
+	count: number;
+};
+
+/** Everything the link list and the analytics popup show for a single link. */
+export type LinkAnalytics = {
+	/** Running total of views over the link's whole lifetime */
+	total: number;
+	/** Views inside the trailing window, summed from the weekly buckets */
+	recentViews: number;
+	/** Length of the trailing window in weeks */
+	windowWeeks: number;
+	/** Views needed inside the window to not count as stale */
+	threshold: number;
+	/** True when recentViews is below threshold */
+	isStale: boolean;
+	/** Dense series over the trailing window, oldest week first, zero-view weeks included */
+	weeks: ViewWeek[];
+};
+
+/**
+ * Turn stored weekly buckets into per-link analytics, deriving staleness at read time rather
+ * than reading a stored flag.
+ *
+ * Buckets may be passed in for any number of links and in any order, and buckets outside the
+ * trailing window are ignored. Links without a single bucket still get an entry, with an
+ * all-zero series.
+ *
+ * @param links - The links to build analytics for, each with its denormalized running total
+ * @param buckets - Weekly view buckets, as stored (weeks with no views simply absent)
+ * @param now - The moment the trailing window ends, defaults to the current time
+ * @returns Analytics per link id
+ */
+export function buildLinkAnalytics(
+	links: { id: number; viewCount: number }[],
+	buckets: LinkViewWeek[],
+	now: Date = new Date()
+): Map<number, LinkAnalytics> {
+	// The window is the current week plus the weeks before it, so it ends on the week we are in
+	const windowStart = addWeeks(utcWeekStart(now), -(STALE_LINK_WINDOW_WEEKS - 1));
+
+	const countsByLink = new Map<number, Map<number, number>>();
+	for (const bucket of buckets) {
+		const weekStart = utcWeekStart(new Date(bucket.weekStart)).getTime();
+
+		let weekCounts = countsByLink.get(bucket.linkId);
+		if (!weekCounts) {
+			weekCounts = new Map();
+			countsByLink.set(bucket.linkId, weekCounts);
+		}
+
+		weekCounts.set(weekStart, (weekCounts.get(weekStart) ?? 0) + bucket.count);
+	}
+
+	const analytics = new Map<number, LinkAnalytics>();
+	for (const link of links) {
+		const weekCounts = countsByLink.get(link.id);
+
+		const weeks: ViewWeek[] = [];
+		let recentViews = 0;
+
+		for (let week = 0; week < STALE_LINK_WINDOW_WEEKS; week++) {
+			const weekStart = addWeeks(windowStart, week);
+			const count = weekCounts?.get(weekStart.getTime()) ?? 0;
+
+			recentViews += count;
+			weeks.push({ weekStart, count });
+		}
+
+		analytics.set(link.id, {
+			total: link.viewCount,
+			recentViews,
+			windowWeeks: STALE_LINK_WINDOW_WEEKS,
+			threshold: STALE_LINK_VIEW_THRESHOLD,
+			isStale: recentViews < STALE_LINK_VIEW_THRESHOLD,
+			weeks
+		});
+	}
+
+	return analytics;
+}

--- a/src/routes/graph-editor/courses/[courseCode]/settings/+page.server.ts
+++ b/src/routes/graph-editor/courses/[courseCode]/settings/+page.server.ts
@@ -4,6 +4,7 @@ import prisma from '$lib/server/db/prisma';
 import { whereHasCoursePermission } from '$lib/server/permissions';
 import { CourseActions } from '$lib/server/actions/Courses';
 import { LinkActions } from '$lib/server/actions/Links';
+import { LinkViewActions } from '$lib/server/actions/LinkViews';
 import { graphSchemaWithId } from '$lib/zod/graphSchema';
 import { newLinkSchema, editLinkSchema } from '$lib/zod/linkSchema';
 import { redirect, type ServerLoad } from '@sveltejs/kit';
@@ -52,10 +53,17 @@ export const load = (async ({ params, locals }) => {
 		// TODO: Check if we need pagination here
 		const allUsers = await prisma.user.findMany();
 
+		// Weekly view buckets for every link listed below, so the link list can show view counts
+		// and work out staleness. Reading these needs no more access than reading the links.
+		const linkViews = await LinkViewActions.getWeeklyViews(
+			dbCourse.graphs.flatMap((graph) => graph.links.map((link) => link.id))
+		);
+
 		return {
 			course: dbCourse,
 			user,
 			allUsers,
+			linkViews,
 			editCourseForm: await superValidate(zod(newCourseSchema)),
 			editSuperUserForm: await superValidate(zod(editSuperUserSchema)),
 			changeArchiveForm: await superValidate(zod(changeArchiveSchema)),

--- a/src/routes/graph-editor/courses/[courseCode]/settings/+page.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/settings/+page.svelte
@@ -95,6 +95,7 @@
 		editGraphForm={data.editGraphForm}
 		newLinkForm={data.newLinkForm}
 		editLinkForm={data.editLinkForm}
+		linkViews={data.linkViews}
 		getLinkURL={(link) => `${page.url.origin}/graph/${data.course.uriCode}/${link.name}`}
 		hasAtLeastAdminPermission={hasCoursePermissions(
 			data.user,

--- a/src/routes/graph-editor/courses/[courseCode]/settings/+page.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/settings/+page.svelte
@@ -26,7 +26,7 @@
 </svelte:head>
 
 <section
-	class="prose top-20 z-10 mx-auto mb-4 flex w-full items-center justify-between rounded-lg bg-purple-50/80 p-4 shadow-none shadow-purple-200/70 backdrop-blur sm:sticky sm:border sm:border-purple-200 sm:shadow-lg"
+	class="prose mx-auto mb-4 flex w-full max-w-4xl items-center justify-between border-b border-purple-200 p-4"
 >
 	<div class="flex items-center gap-2">
 		<h1 class="!m-0">{data.course.name}</h1>
@@ -57,7 +57,7 @@
 	{/if}
 </section>
 
-<section class="prose mx-auto p-4">
+<section class="prose mx-auto max-w-4xl p-4">
 	<h2>Super Users</h2>
 	<p>Super Users are the admins and editors of a course.</p>
 	<ul class="text-sm">
@@ -82,7 +82,7 @@
 	/>
 </section>
 
-<section class="prose mx-auto p-4">
+<section class="prose mx-auto max-w-4xl p-4">
 	<h2>Graphs</h2>
 	<p>
 		Graphs are the bread and butter of the Graph Editor! Here you can structure the information in
@@ -105,7 +105,7 @@
 	/>
 </section>
 
-<section class="prose mx-auto p-4">
+<section class="prose mx-auto max-w-4xl p-4">
 	<h2>Programs</h2>
 	<p>
 		This course is part of {data.course.programs.length} program{data.course.programs.length == 1
@@ -134,7 +134,7 @@
 {#if hasCoursePermissions(data.user, data.course, 'CourseAdminORProgramAdminEditor')}
 	<section
 		id="danger-zone"
-		class="prose mx-auto my-12 space-y-2 border-y-2 border-red-700/50 bg-red-100/50 p-4 text-red-900 shadow-red-900/70 sm:rounded-lg sm:border-2 sm:shadow"
+		class="prose mx-auto my-12 max-w-4xl space-y-2 border-y-2 border-red-700/50 bg-red-100/50 p-4 text-red-900 shadow-red-900/70 sm:rounded-lg sm:border-2 sm:shadow"
 	>
 		<h2 class="text-red-950">Danger zone</h2>
 		<div class="flex items-center gap-2">

--- a/src/routes/graph-editor/sandboxes/[sandboxId=int]/settings/+page.server.ts
+++ b/src/routes/graph-editor/sandboxes/[sandboxId=int]/settings/+page.server.ts
@@ -8,6 +8,7 @@ import { SandboxActions } from '$lib/server/actions/Sandboxes';
 import { GraphActions } from '$lib/server/actions/Graphs';
 import { graphSchemaWithId } from '$lib/zod/graphSchema';
 import { LinkActions } from '$lib/server/actions/Links';
+import { LinkViewActions } from '$lib/server/actions/LinkViews';
 
 import { newLinkSchema, editLinkSchema } from '$lib/zod/linkSchema';
 
@@ -48,6 +49,12 @@ export const load = (async ({ params, locals }) => {
 		// TODO: Check if we need pagination here
 		const allUsers = await prisma.user.findMany();
 
+		// Weekly view buckets for every link listed below, so the link list can show view counts
+		// and work out staleness. Reading these needs no more access than reading the links.
+		const linkViews = await LinkViewActions.getWeeklyViews(
+			dbSandbox.graphs.flatMap((graph) => graph.links.map((link) => link.id))
+		);
+
 		return {
 			breadcrumbs: [
 				{ name: 'Home', url: '/graph-editor' },
@@ -58,6 +65,7 @@ export const load = (async ({ params, locals }) => {
 			sandbox: dbSandbox,
 			user,
 			allUsers,
+			linkViews,
 			editSandboxForm: await superValidate(zod(editSandboxSchema)),
 			editSuperUserForm: await superValidate(zod(editSuperUserSchema)),
 			deleteSandboxForm: await superValidate(zod(deleteSandboxSchema)),

--- a/src/routes/graph-editor/sandboxes/[sandboxId=int]/settings/+page.svelte
+++ b/src/routes/graph-editor/sandboxes/[sandboxId=int]/settings/+page.svelte
@@ -52,6 +52,7 @@
 		editGraphForm={data.editGraphForm}
 		newLinkForm={data.newLinkForm}
 		editLinkForm={data.editLinkForm}
+		linkViews={data.linkViews}
 		getLinkURL={() => `SANDBOX LINKS ARE NOT SUPPORTED YET`}
 		hasAtLeastAdminPermission={hasSandboxPermissions(data.user, data.sandbox, 'Owner')}
 	/>

--- a/src/routes/graph-editor/sandboxes/[sandboxId=int]/settings/+page.svelte
+++ b/src/routes/graph-editor/sandboxes/[sandboxId=int]/settings/+page.svelte
@@ -19,13 +19,13 @@
 </svelte:head>
 
 <section
-	class="prose top-20 z-10 mx-auto mb-4 flex w-full items-center justify-between rounded-lg bg-purple-50/80 p-4 shadow-none shadow-purple-200/70 backdrop-blur sm:sticky sm:border sm:border-purple-200 sm:shadow-lg"
+	class="prose mx-auto mb-4 flex w-full max-w-4xl items-center justify-between border-b border-purple-200 p-4"
 >
 	<h1 class="!m-0">{data.sandbox.name}</h1>
 	<EditSandbox />
 </section>
 
-<section class="prose container mx-auto mt-8 p-4">
+<section class="prose mx-auto mt-8 max-w-4xl p-4">
 	<h2 class="m-0">Sandbox Editors</h2>
 
 	<p>
@@ -36,7 +36,7 @@
 	<EditorTable sandbox={data.sandbox} />
 </section>
 
-<section class="prose mx-auto p-4">
+<section class="prose mx-auto max-w-4xl p-4">
 	<h2>Graphs</h2>
 	<p>
 		Graphs are the bread and butter of the Graph Editor! They are perfect for structuring
@@ -60,7 +60,7 @@
 
 <section
 	id="danger-zone"
-	class="prose mx-auto my-12 space-y-2 border-y-2 border-red-700/50 bg-red-100/50 p-4 text-red-900 shadow-red-900/70 sm:rounded-lg sm:border-2 sm:shadow"
+	class="prose mx-auto my-12 max-w-4xl space-y-2 border-y-2 border-red-700/50 bg-red-100/50 p-4 text-red-900 shadow-red-900/70 sm:rounded-lg sm:border-2 sm:shadow"
 >
 	<h2 class="text-red-950">Danger zone</h2>
 	<div class="flex items-center gap-2">

--- a/src/routes/graph/[code]/[alias]/+page.server.ts
+++ b/src/routes/graph/[code]/[alias]/+page.server.ts
@@ -1,4 +1,5 @@
 import { GraphActions } from '$lib/server/actions/Graphs';
+import { LinkViewActions } from '$lib/server/actions/LinkViews';
 import { error, isHttpError, type ServerLoad } from '@sveltejs/kit';
 
 export const load: ServerLoad = async ({ params }) => {
@@ -11,16 +12,25 @@ export const load: ServerLoad = async ({ params }) => {
 
 	let graph;
 	try {
-		graph = await GraphActions.getRenderablePayload({
-			course: {
-				uriCode: encodeURIComponent(courseCode)
+		graph = await GraphActions.getRenderablePayload(
+			{
+				course: {
+					uriCode: encodeURIComponent(courseCode)
+				},
+				links: {
+					some: {
+						name: alias
+					}
+				}
 			},
-			links: {
-				some: {
-					name: alias
+			{
+				// The link that resolved this page, so its view can be counted below
+				links: {
+					where: { name: alias },
+					select: { id: true }
 				}
 			}
-		});
+		);
 	} catch (e: unknown) {
 		if (isHttpError(e)) throw e;
 		error(500, { message: e instanceof Error ? e.message : `${e}` });
@@ -28,8 +38,17 @@ export const load: ServerLoad = async ({ params }) => {
 
 	if (!graph) error(404, { message: 'Graph not found' });
 
+	// The resolved link is only needed to count the view, the viewer itself has no use for it
+	const { links: resolvedLinks, ...graphPayload } = graph;
+
+	// Count the view. This route is the only public way into a graph, so the graph-editor's own
+	// loaders (which fetch graphs by id) never count. Not awaited on purpose: recording a view
+	// must not add latency to this response, and recordView swallows its own failures.
+	const linkId = resolvedLinks[0]?.id;
+	if (linkId != undefined) void LinkViewActions.recordView(linkId);
+
 	// Happy path
 	return {
-		graph: graph
+		graph: graphPayload
 	};
 };


### PR DESCRIPTION
## Per-link view counting and analytics

Links had no notion of usage, so there was no way to tell which shareable graph links are
actively used and which are dead, and no history of graph traffic at all. This adds aggregate
view counting per link, a weekly history table, a stale-link indicator, and an analytics popup
in the graph-editor link list.

No visitor identity is stored anywhere in this feature: no IP, no session, no cookie, no user
id. The only things written are a running total per link and a count per link per week.

### What was added

**Data model** (`prisma/migrations/20260824101500_add_link_view_counts`)

- `Link.viewCount`, a denormalized running total.
- New `LinkViewWeek` table keyed `@@id([linkId, weekStart])`, holding a count per link per week.
  `weekStart` is a `DATE` on the UTC Monday, as produced by `date_trunc('week', ...)`. A week
  with no views has no row, so the table only grows for links that are actually used.

**Write path** (`src/lib/server/actions/LinkViews.ts`)

- `LinkViewActions.recordView` does one `INSERT ... ON CONFLICT DO UPDATE count = count + 1`
  plus an atomic `increment` on the total, in a single transaction. Both are one statement each,
  so concurrent views cannot lose a count, and the week boundary comes from Postgres so every
  bucket lands on the same UTC Monday regardless of where the app runs.
- It never throws. Failures are caught and logged.
- The public viewer (`/graph/[code]/[alias]`) resolves the link id through its existing query and
  calls it without awaiting, so recording a view cannot add latency to, or fail, the page
  response. The resolved link is stripped again, leaving the public payload unchanged.
- The graph-editor loads graphs by id and never goes through this route, so authoring and preview
  do not count as views.

**Read path**

- `buildLinkAnalytics` (`src/lib/utils/linkAnalytics.ts`) derives the total, the trailing-window
  sum, and staleness from the weekly buckets at read time. Staleness is not a stored flag.
- Thresholds live in `src/lib/settings.ts`: `STALE_LINK_WINDOW_WEEKS = 52`,
  `STALE_LINK_VIEW_THRESHOLD = 10`.
- Week numbering is presentation only. `src/lib/utils/academicWeeks.ts` converts UTC week starts
  to TU Delft academic weeks (week 1 is the week containing 1 September). Storage stays on plain
  UTC week boundaries. Month names are spelled out rather than taken from `toLocaleDateString`,
  so labels do not differ between server and browser locale data.

**UI** (course settings and sandbox settings link lists)

- View count per link in the list.
- `Analytics` action opening a popup with the all-time total, the trailing 52 week total, a
  weekly column chart, and a table of the weeks that have views.
- `Stale` badge on links under the threshold, with a popover naming the actual count and the
  threshold, and stating that nothing happens to a stale link automatically.
- All links / Only stale / Hide stale toggle, filtering data that is already loaded. No extra
  query, no reload.

### Fixes to the surrounding pages

- Settings page sections were capped at `prose`'s 65ch (595px in a 1422px viewport) and the rows
  overflowed: "Graph settings" was cut mid-word and the delete button was unreachable. Sections
  now use `max-w-4xl` (896px) and nothing overflows.
- The table gets a `min-w-[42rem]` so `Table.Root`'s own scroll container scrolls on narrow
  screens instead of squeezing the URL and the buttons into each other.
- The course name and sandbox name headers are no longer sticky, and the card (rounded corners,
  background, border ring, shadow) is replaced by a single bottom border.
- Action buttons on graph rows are right aligned, matching the link rows below them.
- Rows that are not clickable no longer tint on hover, including the Name/Actions header and the
  week table in the modal. Only buttons respond to hover. `table-row.svelte` is untouched, since
  `CoursesTable` and `LinkCourseDataTable` do have clickable rows where the tint is real feedback.
- The analytics modal is wider (896px instead of 512px) through a new opt-in `contentClass` prop
  on `DialogButton`. Note that `dialog-content.svelte` ships `sm:max-w-lg`, which tailwind-merge
  does not treat as conflicting with an unprefixed `max-w-*`, so a width override has to be set
  on the `sm:` variant. Other dialogs are unchanged.
- New `.scrollbar-subtle` utility in `app.css` for the two scroll areas in the modal: transparent
  track, faint purple thumb, instead of the dark browser default.

### Tests

| Suite | Result |
| --- | --- |
| `pnpm test` | 36 passed (4 files), 18 of them new |
| `pnpm test:integration` | 9 passed (2 files), 8 of them new, against real Postgres |
| `pnpm check` | 0 errors, 0 warnings across 6402 files |
| `pnpm lint` | eslint clean, prettier clean on every file touched here |

New unit tests: `src/lib/utils/academicWeeks.test.ts` (10) covers UTC week snapping, week
arithmetic, and academic week numbering including the year boundary where 1 September falls on a
Sunday. `src/lib/utils/linkAnalytics.test.ts` (8) covers the dense series, the window edge, links
without buckets, and the staleness comparison.

New integration tests: `src/lib/server/actions/tests/linkViews.test.ts` (8) run against a real
database and cover the upsert increment, the bucket landing on the UTC Monday, counts staying
separate per link, a failed write being swallowed with nothing written, the trailing window
filter, and staleness staying derived from what was read.

The hand-written migration was checked with `prisma migrate deploy` on an empty database followed
by `prisma migrate diff`, which reports no difference against `schema.prisma`.

### Manual verification

Against a dev server on a throwaway database:

- Loading a public link returns 200 and increments both the total and the current week bucket.
- An unknown alias and an unknown course code both 404 and increment nothing.
- Loading the same graph in the graph-editor, following its redirect, increments nothing.
- The Analytics popup, the stale popover, and both filter directions behave as described.

### Migration note

The migration is additive: one `ADD COLUMN ... DEFAULT 0` and one `CREATE TABLE`. Nothing is
dropped and no rows are touched. Deployment rebuilds the schema from `schema.prisma` via
`db push --force-reset`, so this only matters for local databases. If yours was built with
`db push` and has no migration history, apply
`prisma/migrations/20260824101500_add_link_view_counts/migration.sql` directly rather than
running `db push`, which would also apply unrelated pending schema changes.

### Out of scope

No visitor-level tracking, deduplication, or bot filtering. No server-side filtering or sorting
by staleness, the toggle is client side only. No finer granularity than weekly. Nothing deletes
or archives stale links, this only surfaces staleness. No new permission tier: seeing a link's
analytics needs exactly the access that seeing the link list already needs.

### Also in this branch

Two already-reviewed pieces were merged in here and will come along, which is where the lockfile
churn comes from:

- #150, package updates (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`).
- #146, unit coverage for the permission where-fragment helpers
  (`src/lib/server/permissions.test.ts`).

### Known behaviour worth a decision

A brand new link has 0 views in the window, so it is flagged stale immediately. That follows the
spec as written. Exempting links created inside the window would be a small follow-up if that
reads wrong in practice.