### PR TITLE
fix: truncate long entity names in relationship tables and menus

### DIFF
--- a/src/routes/graph-editor/graphs/[graphid=int]/domains/+page.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/domains/+page.svelte
@@ -314,7 +314,9 @@
 
 	<DropdownMenu.Root>
 		<DropdownMenu.Trigger class={cn('relative w-full', buttonVariants({ variant: 'outline' }))}>
-			<span class="w-full text-left">{thisDomain.name}</span>
+			<span class="min-w-0 flex-1 truncate text-left" title={thisDomain.name}>
+				{thisDomain.name}
+			</span>
 			<ChevronRight />
 		</DropdownMenu.Trigger>
 		<DropdownMenu.Content class="max-h-96 max-w-64 overflow-y-auto p-0">

--- a/src/routes/graph-editor/graphs/[graphid=int]/domains/ChangeDomain.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/domains/ChangeDomain.svelte
@@ -131,7 +131,12 @@
 			<Menubar.SubContent class="ml-1 w-32 p-1">
 				{#each domains as domain (domain.id)}
 					<div class="flex flex-col items-center gap-1">
-						<Button class="w-full font-mono text-xs" href="#domain-{domain.id}" variant="ghost">
+						<Button
+							class="w-full truncate font-mono text-xs"
+							href="#domain-{domain.id}"
+							title={domain.name}
+							variant="ghost"
+						>
 							{domain.name}
 						</Button>
 					</div>

--- a/src/routes/graph-editor/graphs/[graphid=int]/domains/ChangeDomainRel.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/domains/ChangeDomainRel.svelte
@@ -77,7 +77,7 @@
 		loading={fromStore(delayed).current}
 		loadingMessage="Changing to {domain.name} relationship..."
 	>
-		<Replace />
-		{domain.name}
+		<Replace class="shrink-0" />
+		<span class="min-w-0 truncate" title={domain.name}>{domain.name}</span>
 	</Form.FormButton>
 </form>

--- a/src/routes/graph-editor/graphs/[graphid=int]/lectures/+page.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/lectures/+page.svelte
@@ -114,7 +114,9 @@
 					<MoveVertical class="h-4 w-4" />
 				</div>
 
-				<p class="m-0 mr-auto text-lg font-bold">{lecture.name}</p>
+				<p class="m-0 mr-auto min-w-0 flex-1 truncate text-lg font-bold" title={lecture.name}>
+					{lecture.name}
+				</p>
 				<IssueIndicator issues={lectureIssues.lecture} />
 
 				{#if data.graph.subjects.length > 0}

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/+page.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/+page.svelte
@@ -127,7 +127,7 @@
 			</Grid.Cell>
 
 			<Grid.Cell>
-				{subject.name}
+				<p class="m-0 truncate" title={subject.name}>{subject.name}</p>
 			</Grid.Cell>
 
 			<Grid.Cell>
@@ -185,7 +185,9 @@
 
 	<DropdownMenu.Root>
 		<DropdownMenu.Trigger class={cn('relative w-full', buttonVariants({ variant: 'outline' }))}>
-			<span class="w-full text-left">{thisSubject.name}</span>
+			<span class="min-w-0 flex-1 truncate text-left" title={thisSubject.name}>
+				{thisSubject.name}
+			</span>
 			<ChevronRight />
 		</DropdownMenu.Trigger>
 		<DropdownMenu.Content class="max-h-96 max-w-64 overflow-y-auto p-0">

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeDomainForSubject.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeDomainForSubject.svelte
@@ -39,7 +39,7 @@
 				'!hover:bg-orange-900 !bg-orange-300/20 text-orange-900 hover:text-orange-900'
 		)}
 	>
-		<span class="grow text-left">
+		<span class="min-w-0 grow truncate text-left" title={subject.domain?.name}>
 			{#if subject.domain}
 				{subject.domain.name}
 			{:else}

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubject.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubject.svelte
@@ -117,7 +117,12 @@
 			<Menubar.SubContent class="ml-1 w-32 p-1">
 				{#each subjects as subject (subject.id)}
 					<div class="flex flex-col items-center gap-1">
-						<Button class="w-full font-mono text-xs" href="#subject-{subject.id}" variant="ghost">
+						<Button
+							class="w-full truncate font-mono text-xs"
+							href="#subject-{subject.id}"
+							title={subject.name}
+							variant="ghost"
+						>
 							{subject.name}
 						</Button>
 					</div>
@@ -157,12 +162,18 @@
 								<span class="font-mono text-xs font-normal text-gray-400">(Optional)</span>
 							</Form.Label>
 							<Popover.Trigger
-								class={cn(buttonVariants({ variant: 'outline' }), 'min-w-[50%] justify-between')}
+								class={cn(
+									buttonVariants({ variant: 'outline' }),
+									'max-w-full min-w-[50%] justify-between'
+								)}
 								role="combobox"
 								{...props}
 							>
-								{graph.domains.find((f) => f.id === $formData.domainId)?.name ?? 'Select domain'}
-								<ChevronsUpDown class="opacity-50" />
+								{@const selectedDomainName =
+									graph.domains.find((f) => f.id === $formData.domainId)?.name ?? 'Select domain'}
+								<span class="min-w-0 truncate" title={selectedDomainName}>{selectedDomainName}</span
+								>
+								<ChevronsUpDown class="shrink-0 opacity-50" />
 							</Popover.Trigger>
 							<input hidden value={$formData.domainId} name={props.name} />
 						</div>

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubjectRel.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubjectRel.svelte
@@ -77,7 +77,7 @@
 		loading={fromStore(delayed).current}
 		loadingMessage="Changing to {subject.name} relationship..."
 	>
-		<Replace />
-		{subject.name}
+		<Replace class="shrink-0" />
+		<span class="min-w-0 truncate" title={subject.name}>{subject.name}</span>
 	</Form.FormButton>
 </form>


### PR DESCRIPTION
## Summary
- Domain/subject relationship table dropdown triggers now truncate name text with ellipsis instead of overflowing the button
- Subjects list name cell, lecture name, domain-picker cells/menus, and sub-menu relation buttons now truncate too (same missing pattern, audited across the graph-editor tables)
- Truncated names keep a `title` attribute so the full name is still available on hover

Fixes #168