### PR TITLE
Replace popup help buttons with links to the manual

### DIFF
--- a/src/lib/components/Help.svelte
+++ b/src/lib/components/Help.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
 	import { buttonVariants } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils';
+	import { manualLabel, manualUrl, type ManualPage } from '$lib/manual';
 	import { BadgeHelp } from '@lucide/svelte';
 
 	type Props = {
-		href: string;
+		page: ManualPage;
 	};
 
-	const { href }: Props = $props();
+	const { page }: Props = $props();
 </script>
 
 <!-- eslint-disable svelte/no-navigation-without-resolve -- external manual link, not a SvelteKit route -->
 <a
-	{href}
+	href={manualUrl(page)}
 	target="_blank"
 	rel="noopener noreferrer"
 	class={cn(
@@ -22,6 +23,6 @@
 	)}
 >
 	<BadgeHelp class="size-5" />
-	<span>Help</span>
+	<span>{manualLabel(page)} help</span>
 </a>
 <!-- eslint-enable svelte/no-navigation-without-resolve -->

--- a/src/lib/components/Help.svelte
+++ b/src/lib/components/Help.svelte
@@ -1,20 +1,27 @@
 <script lang="ts">
-	import type { Snippet } from 'svelte';
-	import DialogButton from './DialogButton.svelte';
+	import { buttonVariants } from '$lib/components/ui/button';
+	import { cn } from '$lib/utils';
+	import { BadgeHelp } from '@lucide/svelte';
 
 	type Props = {
-		title: string;
-		children: Snippet<[]>;
+		href: string;
 	};
 
-	const { title, children }: Props = $props();
+	const { href }: Props = $props();
 </script>
 
-<DialogButton
-	{title}
-	button="Help"
-	icon="help"
-	class="fixed top-2 right-4 z-20 gap-1 bg-transparent text-white hover:underline"
+<!-- eslint-disable svelte/no-navigation-without-resolve -- external manual link, not a SvelteKit route -->
+<a
+	{href}
+	target="_blank"
+	rel="noopener noreferrer"
+	class={cn(
+		'flex items-center gap-2 rounded p-2 text-sm text-nowrap shadow-none transition-all hover:shadow-lg',
+		buttonVariants({ variant: 'default' }),
+		'fixed top-2 right-4 z-20 gap-1 bg-transparent text-white hover:underline'
+	)}
 >
-	{@render children()}
-</DialogButton>
+	<BadgeHelp class="size-5" />
+	<span>Help</span>
+</a>
+<!-- eslint-enable svelte/no-navigation-without-resolve -->

--- a/src/lib/manual.ts
+++ b/src/lib/manual.ts
@@ -1,0 +1,23 @@
+// Single source of truth for app route -> graaf manual page mapping.
+// Manual source: manual/src/content/docs/*.mdx, deployed to prime-tu-delft.github.io/graaf.
+
+const MANUAL_BASE_URL = 'https://prime-tu-delft.github.io/graaf';
+
+const manualPagePaths = {
+	about: '/about/',
+	programmes: '/programmes/',
+	programmeSettings: '/programmes/#editing-a-programme',
+	courses: '/courses/',
+	courseSettings: '/courses/#course-settings',
+	graphs: '/graphs/',
+	domains: '/domains/',
+	subjects: '/subjects/',
+	lectures: '/lectures/',
+	links: '/links/'
+} as const;
+
+export type ManualPage = keyof typeof manualPagePaths;
+
+export function manualUrl(page: ManualPage) {
+	return `${MANUAL_BASE_URL}${manualPagePaths[page]}`;
+}

--- a/src/lib/manual.ts
+++ b/src/lib/manual.ts
@@ -16,8 +16,25 @@ const manualPagePaths = {
 	links: '/links/'
 } as const;
 
+const manualPageLabels = {
+	about: 'About',
+	programmes: 'Programmes',
+	programmeSettings: 'Programme settings',
+	courses: 'Courses',
+	courseSettings: 'Course settings',
+	graphs: 'Graphs',
+	domains: 'Domains',
+	subjects: 'Subjects',
+	lectures: 'Lectures',
+	links: 'Links'
+} as const;
+
 export type ManualPage = keyof typeof manualPagePaths;
 
 export function manualUrl(page: ManualPage) {
 	return `${MANUAL_BASE_URL}${manualPagePaths[page]}`;
+}
+
+export function manualLabel(page: ManualPage) {
+	return manualPageLabels[page];
 }

--- a/src/routes/graph-editor/+page.svelte
+++ b/src/routes/graph-editor/+page.svelte
@@ -6,6 +6,7 @@
 	import { page } from '$app/state';
 	import Help from '$lib/components/Help.svelte';
 	import { buttonVariants } from '$lib/components/ui/button';
+	import { manualUrl } from '$lib/manual';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { cn } from '$lib/utils';
 	import { Archive, ArchiveX } from '@lucide/svelte';
@@ -34,12 +35,7 @@
 	<title>Dashboard | PRIME Graph Editor</title>
 </svelte:head>
 
-<Help title="Home page">
-	<p>
-		The home page is where you can find Programmes, Courses and Sandboxes you're working on. You can
-		pin courses to the top of the page, and filter Programmes by unarchived courses.
-	</p>
-</Help>
+<Help href={manualUrl('about')} />
 
 <article class="my-6 mb-12 space-y-8">
 	<section class="prose mx-auto p-4">

--- a/src/routes/graph-editor/+page.svelte
+++ b/src/routes/graph-editor/+page.svelte
@@ -6,7 +6,6 @@
 	import { page } from '$app/state';
 	import Help from '$lib/components/Help.svelte';
 	import { buttonVariants } from '$lib/components/ui/button';
-	import { manualUrl } from '$lib/manual';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { cn } from '$lib/utils';
 	import { Archive, ArchiveX } from '@lucide/svelte';
@@ -35,7 +34,7 @@
 	<title>Dashboard | PRIME Graph Editor</title>
 </svelte:head>
 
-<Help href={manualUrl('about')} />
+<Help page="about" />
 
 <article class="my-6 mb-12 space-y-8">
 	<section class="prose mx-auto p-4">

--- a/src/routes/graph-editor/courses/+page.svelte
+++ b/src/routes/graph-editor/courses/+page.svelte
@@ -5,6 +5,8 @@
 
 	// Components
 	import DialogButton from '$lib/components/DialogButton.svelte';
+	import Help from '$lib/components/Help.svelte';
+	import { manualUrl } from '$lib/manual';
 	import * as Accordion from '$lib/components/ui/accordion/index.js';
 	import { Button } from '$lib/components/ui/button';
 	import { displayName } from '$lib/utils/displayUserName';
@@ -52,6 +54,7 @@
 	<title>Courses | PRIME Graph Editor</title>
 </svelte:head>
 
+<Help href={manualUrl('courses')} />
 <section class="prose mx-auto mt-12 p-4">
 	<h1 class="text-purple-950 shadow-purple-500/70">Courses</h1>
 	<p>

--- a/src/routes/graph-editor/courses/+page.svelte
+++ b/src/routes/graph-editor/courses/+page.svelte
@@ -6,7 +6,6 @@
 	// Components
 	import DialogButton from '$lib/components/DialogButton.svelte';
 	import Help from '$lib/components/Help.svelte';
-	import { manualUrl } from '$lib/manual';
 	import * as Accordion from '$lib/components/ui/accordion/index.js';
 	import { Button } from '$lib/components/ui/button';
 	import { displayName } from '$lib/utils/displayUserName';
@@ -54,7 +53,7 @@
 	<title>Courses | PRIME Graph Editor</title>
 </svelte:head>
 
-<Help href={manualUrl('courses')} />
+<Help page="courses" />
 <section class="prose mx-auto mt-12 p-4">
 	<h1 class="text-purple-950 shadow-purple-500/70">Courses</h1>
 	<p>

--- a/src/routes/graph-editor/courses/[courseCode]/+page.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/+page.svelte
@@ -7,6 +7,8 @@
 	import CreateGraph from '$lib/components/graphSettings/CreateGraph.svelte';
 	import DuplicateGraph from '$lib/components/graphSettings/DuplicateGraph.svelte';
 	import GraphSettings from '$lib/components/graphSettings/GraphSettings.svelte';
+	import Help from '$lib/components/Help.svelte';
+	import { manualUrl } from '$lib/manual';
 	import ShowAdmins from './ShowAdmins.svelte';
 
 	// Icons
@@ -35,6 +37,8 @@
 		>{data.course ? `${data.course.code} ${data.course.name}` : 'Course'} | PRIME Graph Editor</title
 	>
 </svelte:head>
+
+<Help href={manualUrl('graphs')} />
 
 <article class="my-6 mb-12 space-y-6">
 	{#if data.error != undefined}

--- a/src/routes/graph-editor/courses/[courseCode]/+page.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/+page.svelte
@@ -8,7 +8,6 @@
 	import DuplicateGraph from '$lib/components/graphSettings/DuplicateGraph.svelte';
 	import GraphSettings from '$lib/components/graphSettings/GraphSettings.svelte';
 	import Help from '$lib/components/Help.svelte';
-	import { manualUrl } from '$lib/manual';
 	import ShowAdmins from './ShowAdmins.svelte';
 
 	// Icons
@@ -38,7 +37,7 @@
 	>
 </svelte:head>
 
-<Help href={manualUrl('graphs')} />
+<Help page="graphs" />
 
 <article class="my-6 mb-12 space-y-6">
 	{#if data.error != undefined}

--- a/src/routes/graph-editor/courses/[courseCode]/settings/+page.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/settings/+page.svelte
@@ -3,7 +3,6 @@
 	import { resolve } from '$app/paths';
 	import DialogButton from '$lib/components/DialogButton.svelte';
 	import Help from '$lib/components/Help.svelte';
-	import { manualUrl } from '$lib/manual';
 	import { hasCoursePermissions, hasProgramPermissions } from '$lib/utils/permissions';
 	import ArchiveCourse from './ArchiveCourse.svelte';
 	import EditCourseName from './EditCourseName.svelte';
@@ -27,7 +26,7 @@
 	<title>{data.course.name} Settings | PRIME Graph Editor</title>
 </svelte:head>
 
-<Help href={manualUrl('courseSettings')} />
+<Help page="courseSettings" />
 
 <section
 	class="prose top-20 z-10 mx-auto mb-4 flex w-full items-center justify-between rounded-lg bg-purple-50/80 p-4 shadow-none shadow-purple-200/70 backdrop-blur sm:sticky sm:border sm:border-purple-200 sm:shadow-lg"

--- a/src/routes/graph-editor/courses/[courseCode]/settings/+page.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/settings/+page.svelte
@@ -2,6 +2,8 @@
 	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
 	import DialogButton from '$lib/components/DialogButton.svelte';
+	import Help from '$lib/components/Help.svelte';
+	import { manualUrl } from '$lib/manual';
 	import { hasCoursePermissions, hasProgramPermissions } from '$lib/utils/permissions';
 	import ArchiveCourse from './ArchiveCourse.svelte';
 	import EditCourseName from './EditCourseName.svelte';
@@ -24,6 +26,8 @@
 <svelte:head>
 	<title>{data.course.name} Settings | PRIME Graph Editor</title>
 </svelte:head>
+
+<Help href={manualUrl('courseSettings')} />
 
 <section
 	class="prose top-20 z-10 mx-auto mb-4 flex w-full items-center justify-between rounded-lg bg-purple-50/80 p-4 shadow-none shadow-purple-200/70 backdrop-blur sm:sticky sm:border sm:border-purple-200 sm:shadow-lg"

--- a/src/routes/graph-editor/graphs/[graphid=int]/+layout.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/+layout.svelte
@@ -10,7 +10,6 @@
 	import GraphRenderer from '$lib/components/GraphRenderer.svelte';
 	import Help from '$lib/components/Help.svelte';
 	import { graphState } from '$lib/d3/GraphD3State.svelte';
-	import { manualUrl } from '$lib/manual';
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
 
 	import type { Snippet } from 'svelte';
@@ -62,7 +61,7 @@
 	);
 </script>
 
-<Help href={manualUrl(manualPageForView)} />
+<Help page={manualPageForView} />
 
 <div class="mx-auto max-w-[100rem]">
 	<PaneGroup direction="horizontal" autoSaveId="panels" class="w-full !overflow-visible">

--- a/src/routes/graph-editor/graphs/[graphid=int]/+layout.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/+layout.svelte
@@ -8,7 +8,9 @@
 	import { Check, ChevronDown, GripVertical } from '@lucide/svelte';
 	import { Pane, PaneGroup, PaneResizer } from 'paneforge';
 	import GraphRenderer from '$lib/components/GraphRenderer.svelte';
+	import Help from '$lib/components/Help.svelte';
 	import { graphState } from '$lib/d3/GraphD3State.svelte';
+	import { manualUrl } from '$lib/manual';
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
 
 	import type { Snippet } from 'svelte';
@@ -54,7 +56,13 @@
 	function capitalize(str: string) {
 		return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 	}
+
+	const manualPageForView = $derived(
+		view === 'DOMAINS' ? 'domains' : view === 'SUBJECTS' ? 'subjects' : 'lectures'
+	);
 </script>
+
+<Help href={manualUrl(manualPageForView)} />
 
 <div class="mx-auto max-w-[100rem]">
 	<PaneGroup direction="horizontal" autoSaveId="panels" class="w-full !overflow-visible">

--- a/src/routes/graph-editor/programs/+page.svelte
+++ b/src/routes/graph-editor/programs/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import type { User } from '@prisma/client';
+	import Help from '$lib/components/Help.svelte';
+	import { manualUrl } from '$lib/manual';
 	import CreateNewProgramButton from '../newProgramButton.svelte';
 	import Program from '../Program.svelte';
 	import SearchCourses from '../SearchCourses.svelte';
@@ -13,6 +15,7 @@
 	<title>Programs | PRIME Graph Editor</title>
 </svelte:head>
 
+<Help href={manualUrl('programmes')} />
 <section class="prose mx-auto mt-12 p-4">
 	<h1 class="text-purple-950 shadow-purple-500/70">Programmes</h1>
 	<p>

--- a/src/routes/graph-editor/programs/+page.svelte
+++ b/src/routes/graph-editor/programs/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { User } from '@prisma/client';
 	import Help from '$lib/components/Help.svelte';
-	import { manualUrl } from '$lib/manual';
 	import CreateNewProgramButton from '../newProgramButton.svelte';
 	import Program from '../Program.svelte';
 	import SearchCourses from '../SearchCourses.svelte';
@@ -15,7 +14,7 @@
 	<title>Programs | PRIME Graph Editor</title>
 </svelte:head>
 
-<Help href={manualUrl('programmes')} />
+<Help page="programmes" />
 <section class="prose mx-auto mt-12 p-4">
 	<h1 class="text-purple-950 shadow-purple-500/70">Programmes</h1>
 	<p>

--- a/src/routes/graph-editor/programs/[programId=int]/settings/+page.svelte
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/+page.svelte
@@ -3,6 +3,8 @@
 	import { columns } from './courses/course-columns';
 
 	import DialogButton from '$lib/components/DialogButton.svelte';
+	import Help from '$lib/components/Help.svelte';
+	import { manualUrl } from '$lib/manual';
 	import SuperUserTable from './superUsers/SuperUserTable.svelte';
 	import CoursesTable from './courses/CoursesTable.svelte';
 	import EditProgramName from './EditProgramName.svelte';
@@ -18,6 +20,8 @@
 <svelte:head>
 	<title>{data.program.name} Settings | PRIME Graph Editor</title>
 </svelte:head>
+
+<Help href={manualUrl('programmeSettings')} />
 
 <section
 	class="prose top-20 z-10 mx-auto mb-4 flex w-full items-center justify-between rounded-lg bg-purple-50/80 p-4 shadow-none shadow-purple-200/70 backdrop-blur sm:sticky sm:border sm:border-purple-200 sm:shadow-lg"

--- a/src/routes/graph-editor/programs/[programId=int]/settings/+page.svelte
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/+page.svelte
@@ -4,7 +4,6 @@
 
 	import DialogButton from '$lib/components/DialogButton.svelte';
 	import Help from '$lib/components/Help.svelte';
-	import { manualUrl } from '$lib/manual';
 	import SuperUserTable from './superUsers/SuperUserTable.svelte';
 	import CoursesTable from './courses/CoursesTable.svelte';
 	import EditProgramName from './EditProgramName.svelte';
@@ -21,7 +20,7 @@
 	<title>{data.program.name} Settings | PRIME Graph Editor</title>
 </svelte:head>
 
-<Help href={manualUrl('programmeSettings')} />
+<Help page="programmeSettings" />
 
 <section
 	class="prose top-20 z-10 mx-auto mb-4 flex w-full items-center justify-between rounded-lg bg-purple-50/80 p-4 shadow-none shadow-purple-200/70 backdrop-blur sm:sticky sm:border sm:border-purple-200 sm:shadow-lg"


### PR DESCRIPTION
## Summary
- `Help.svelte` now links out to the relevant graaf manual page (new tab) instead of opening a popup dialog with hardcoded text
- Added `src/lib/manual.ts` as a single source of truth for app route -> manual page mapping
- Added help buttons to programmes, courses, course settings, programme settings, and the domains/subjects/lectures graph views, each pointing at the matching manual page/anchor

Closes #167