### PR TITLE
fix: log server errors before converting to a 500

### DIFF
--- a/src/routes/graph-editor/graphs/[graphid=int]/+layout.server.ts
+++ b/src/routes/graph-editor/graphs/[graphid=int]/+layout.server.ts
@@ -58,6 +58,7 @@ export const load: LayoutServerLoad = async ({ params }) => {
 		};
 	} catch (e: unknown) {
 		if (isRedirect(e)) throw e;
+		console.error(e);
 		error(500, { message: e instanceof Error ? e.message : `${e}` });
 	}
 };

--- a/src/routes/graph/[code]/[alias]/+page.server.ts
+++ b/src/routes/graph/[code]/[alias]/+page.server.ts
@@ -23,6 +23,7 @@ export const load: ServerLoad = async ({ params }) => {
 		});
 	} catch (e: unknown) {
 		if (isHttpError(e)) throw e;
+		console.error(e);
 		error(500, { message: e instanceof Error ? e.message : `${e}` });
 	}
 


### PR DESCRIPTION
error() from @sveltejs/kit marks the error as expected, which suppresses SvelteKit's default console logging, so the real stack trace is lost when these routes wrap exceptions.